### PR TITLE
Full Changes

### DIFF
--- a/reports/noa_805968_20250829_214807.json
+++ b/reports/noa_805968_20250829_214807.json
@@ -1,0 +1,227 @@
+{
+  "summary": {
+    "node": "NOA",
+    "seed": 805968,
+    "epochs": 10,
+    "duration": 600,
+    "total_checked": 10,
+    "total_consistent": 8,
+    "total_inconsistent": 2,
+    "score": 80.0,
+    "availability_yes_dataselect_no": 0,
+    "availability_no_dataselect_yes": 2,
+    "timestamp": "2025-08-29T21:48:07.544816+00:00"
+  },
+  "results": [
+    {
+      "index": 3,
+      "url": "https://eida.gein.noa.gr/fdsnws/availability/1/query?network=1Y&station=GR24&location=00&channel=HHE&start=2022-09-28T12:30:00Z&end=2023-01-01T00:00:00Z&format=json",
+      "network": "1Y",
+      "station": "GR24",
+      "channel": "HHE",
+      "location": "00",
+      "available": false,
+      "dataselect_success": false,
+      "dataselect_status": "NoData",
+      "dataselect_type": "NoTrace",
+      "consistent": true,
+      "starttime": "2022-11-14T15:20:36",
+      "endtime": "2022-11-14T15:30:36",
+      "debug": "\u274c No waveform bytes (HTTP 204).\nhttps://eida.gein.noa.gr/fdsnws/dataselect/1/query?network=1Y&station=GR24&location=00&channel=HHE&starttime=2022-11-14T15:20:36&endtime=2022-11-14T15:30:36&nodata=204",
+      "matched_span": {
+        "start": null,
+        "end": null,
+        "location": null
+      }
+    },
+    {
+      "index": 7,
+      "url": "https://eida.gein.noa.gr/fdsnws/availability/1/query?network=HT&station=KPRO&location=*&channel=HHE&start=2011-04-01T00:00:00Z&end=2013-01-18T00:00:00Z&format=json",
+      "network": "HT",
+      "station": "KPRO",
+      "channel": "HHE",
+      "location": "",
+      "available": false,
+      "dataselect_success": true,
+      "dataselect_status": "OK",
+      "dataselect_type": "SingleTrace",
+      "consistent": false,
+      "starttime": "2011-06-29T15:18:22",
+      "endtime": "2011-06-29T15:28:22",
+      "debug": "\u2705 Retrieved 1 trace(s) via ObsPy client.\nHT.KPRO..HHE | 2011-06-29T15:18:22.000000Z - 2011-06-29T15:28:22.000000Z | 100.0 Hz, 60001 samples\nhttps://eida.gein.noa.gr/fdsnws/dataselect/1/query?network=HT&station=KPRO&location=&channel=HHE&starttime=2011-06-29T15:18:22&endtime=2011-06-29T15:28:22&nodata=204",
+      "matched_span": {
+        "start": null,
+        "end": null,
+        "location": null
+      }
+    },
+    {
+      "index": 9,
+      "url": "https://eida.gein.noa.gr/fdsnws/availability/1/query?network=EG&station=MMAA&location=*&channel=EN1&start=2015-08-05T00:00:00Z&end=2025-08-29T21:48:04.240236&format=json",
+      "network": "EG",
+      "station": "MMAA",
+      "channel": "EN1",
+      "location": "",
+      "available": false,
+      "dataselect_success": true,
+      "dataselect_status": "OK",
+      "dataselect_type": "SingleTrace",
+      "consistent": false,
+      "starttime": "2016-01-09T22:41:18",
+      "endtime": "2016-01-09T22:51:18",
+      "debug": "\u2705 Retrieved 1 trace(s) via ObsPy client.\nEG.MMAA..EN1 | 2016-01-09T22:41:18.000000Z - 2016-01-09T22:51:18.000000Z | 200.0 Hz, 120001 samples\nhttps://eida.gein.noa.gr/fdsnws/dataselect/1/query?network=EG&station=MMAA&location=&channel=EN1&starttime=2016-01-09T22:41:18&endtime=2016-01-09T22:51:18&nodata=204",
+      "matched_span": {
+        "start": null,
+        "end": null,
+        "location": null
+      }
+    },
+    {
+      "index": 4,
+      "url": "https://eida.gein.noa.gr/fdsnws/availability/1/query?network=HC&station=THT2&location=*&channel=HHZ&start=2011-11-05T00:00:00Z&end=2015-11-04T00:00:00Z&format=json",
+      "network": "HC",
+      "station": "THT2",
+      "channel": "HHZ",
+      "location": "",
+      "available": false,
+      "dataselect_success": false,
+      "dataselect_status": "NoData",
+      "dataselect_type": "NoTrace",
+      "consistent": true,
+      "starttime": "2013-09-18T20:27:47",
+      "endtime": "2013-09-18T20:37:47",
+      "debug": "\u274c No waveform bytes (HTTP 204).\nhttps://eida.gein.noa.gr/fdsnws/dataselect/1/query?network=HC&station=THT2&location=&channel=HHZ&starttime=2013-09-18T20:27:47&endtime=2013-09-18T20:37:47&nodata=204",
+      "matched_span": {
+        "start": null,
+        "end": null,
+        "location": null
+      }
+    },
+    {
+      "index": 8,
+      "url": "https://eida.gein.noa.gr/fdsnws/availability/1/query?network=1Y&station=GR21&location=00&channel=HHN&start=2022-10-04T13:41:13Z&end=2023-01-01T00:00:00Z&format=json",
+      "network": "1Y",
+      "station": "GR21",
+      "channel": "HHN",
+      "location": "00",
+      "available": true,
+      "dataselect_success": true,
+      "dataselect_status": "OK",
+      "dataselect_type": "SingleTrace",
+      "consistent": true,
+      "starttime": "2022-11-02T15:00:15",
+      "endtime": "2022-11-02T15:10:15",
+      "debug": "\u2705 Retrieved 1 trace(s) via ObsPy client.\n1Y.GR21.00.HHN | 2022-11-02T15:00:15.000000Z - 2022-11-02T15:10:15.000000Z | 100.0 Hz, 60001 samples\nhttps://eida.gein.noa.gr/fdsnws/dataselect/1/query?network=1Y&station=GR21&location=00&channel=HHN&starttime=2022-11-02T15:00:15&endtime=2022-11-02T15:10:15&nodata=204",
+      "matched_span": {
+        "start": "2022-11-02T00:00:00.000000Z",
+        "end": "2022-11-03T00:00:00.000000Z",
+        "location": "00"
+      }
+    },
+    {
+      "index": 2,
+      "url": "https://eida.gein.noa.gr/fdsnws/availability/1/query?network=EG&station=MMAA&location=*&channel=EN3&start=2015-08-05T00:00:00Z&end=2025-08-29T21:47:58.574156&format=json",
+      "network": "EG",
+      "station": "MMAA",
+      "channel": "EN3",
+      "location": "",
+      "available": true,
+      "dataselect_success": true,
+      "dataselect_status": "OK",
+      "dataselect_type": "SingleTrace",
+      "consistent": true,
+      "starttime": "2018-04-23T23:02:01",
+      "endtime": "2018-04-23T23:12:01",
+      "debug": "\u2705 Retrieved 1 trace(s) via ObsPy client.\nEG.MMAA..EN3 | 2018-04-23T23:02:01.000000Z - 2018-04-23T23:12:01.000000Z | 200.0 Hz, 120001 samples\nhttps://eida.gein.noa.gr/fdsnws/dataselect/1/query?network=EG&station=MMAA&location=&channel=EN3&starttime=2018-04-23T23:02:01&endtime=2018-04-23T23:12:01&nodata=204",
+      "matched_span": {
+        "start": "2018-04-23T00:00:00.000000Z",
+        "end": "2018-04-24T00:00:00.000000Z",
+        "location": ""
+      }
+    },
+    {
+      "index": 6,
+      "url": "https://eida.gein.noa.gr/fdsnws/availability/1/query?network=HL&station=NISR&location=00&channel=HNN&start=2019-01-01T00:00:00Z&end=2021-01-15T07:59:00Z&format=json",
+      "network": "HL",
+      "station": "NISR",
+      "channel": "HNN",
+      "location": "00",
+      "available": false,
+      "dataselect_success": false,
+      "dataselect_status": "NoData",
+      "dataselect_type": "NoTrace",
+      "consistent": true,
+      "starttime": "2019-07-18T16:46:54",
+      "endtime": "2019-07-18T16:56:54",
+      "debug": "\u274c No waveform bytes (HTTP 204).\nhttps://eida.gein.noa.gr/fdsnws/dataselect/1/query?network=HL&station=NISR&location=00&channel=HNN&starttime=2019-07-18T16:46:54&endtime=2019-07-18T16:56:54&nodata=204",
+      "matched_span": {
+        "start": null,
+        "end": null,
+        "location": null
+      }
+    },
+    {
+      "index": 5,
+      "url": "https://eida.gein.noa.gr/fdsnws/availability/1/query?network=HL&station=CHNB&location=00&channel=HNE&start=2012-03-26T00:00:00Z&end=2025-08-29T21:48:02.173764&format=json",
+      "network": "HL",
+      "station": "CHNB",
+      "channel": "HNE",
+      "location": "00",
+      "available": true,
+      "dataselect_success": true,
+      "dataselect_status": "OK",
+      "dataselect_type": "SingleTrace",
+      "consistent": true,
+      "starttime": "2024-02-12T18:30:19",
+      "endtime": "2024-02-12T18:40:19",
+      "debug": "\u2705 Retrieved 1 trace(s) via ObsPy client.\nHL.CHNB.00.HNE | 2024-02-12T18:30:19.000000Z - 2024-02-12T18:40:19.000000Z | 200.0 Hz, 120001 samples\nhttps://eida.gein.noa.gr/fdsnws/dataselect/1/query?network=HL&station=CHNB&location=00&channel=HNE&starttime=2024-02-12T18:30:19&endtime=2024-02-12T18:40:19&nodata=204",
+      "matched_span": {
+        "start": "2024-02-12T00:00:00.000000Z",
+        "end": "2024-02-13T00:00:00.000000Z",
+        "location": "00"
+      }
+    },
+    {
+      "index": 10,
+      "url": "https://eida.gein.noa.gr/fdsnws/availability/1/query?network=HL&station=AMGA&location=*&channel=HHN&start=2025-02-04T00:00:00Z&end=2025-08-29T21:48:05.578216&format=json",
+      "network": "HL",
+      "station": "AMGA",
+      "channel": "HHN",
+      "location": "",
+      "available": true,
+      "dataselect_success": true,
+      "dataselect_status": "OK",
+      "dataselect_type": "SingleTrace",
+      "consistent": true,
+      "starttime": "2025-07-27T21:04:34",
+      "endtime": "2025-07-27T21:14:34",
+      "debug": "\u2705 Retrieved 1 trace(s) via ObsPy client.\nHL.AMGA..HHN | 2025-07-27T21:04:34.000000Z - 2025-07-27T21:14:34.000000Z | 100.0 Hz, 60001 samples\nhttps://eida.gein.noa.gr/fdsnws/dataselect/1/query?network=HL&station=AMGA&location=&channel=HHN&starttime=2025-07-27T21:04:34&endtime=2025-07-27T21:14:34&nodata=204",
+      "matched_span": {
+        "start": "2025-07-27T00:00:00.000000Z",
+        "end": "2025-07-28T00:00:00.000000Z",
+        "location": ""
+      }
+    },
+    {
+      "index": 1,
+      "url": "https://eida.gein.noa.gr/fdsnws/availability/1/query?network=HP&station=GUR&location=*&channel=HNN&start=2019-04-18T00:00:00Z&end=2022-11-24T10:00:00Z&format=json",
+      "network": "HP",
+      "station": "GUR",
+      "channel": "HNN",
+      "location": "",
+      "available": true,
+      "dataselect_success": true,
+      "dataselect_status": "OK",
+      "dataselect_type": "SingleTrace",
+      "consistent": true,
+      "starttime": "2019-05-16T07:08:52",
+      "endtime": "2019-05-16T07:18:52",
+      "debug": "\u2705 Retrieved 1 trace(s) via ObsPy client.\nHP.GUR..HNN | 2019-05-16T07:08:52.000000Z - 2019-05-16T07:18:52.000000Z | 100.0 Hz, 60001 samples\nhttps://eida.gein.noa.gr/fdsnws/dataselect/1/query?network=HP&station=GUR&location=&channel=HNN&starttime=2019-05-16T07:08:52&endtime=2019-05-16T07:18:52&nodata=204",
+      "matched_span": {
+        "start": "2019-05-16T00:00:00.000000Z",
+        "end": "2019-05-17T00:00:00.000000Z",
+        "location": ""
+      }
+    }
+  ]
+}

--- a/reports/noa_805968_20250829_214807.md
+++ b/reports/noa_805968_20250829_214807.md
@@ -1,0 +1,101 @@
+# EIDA Consistency Report: `NOA`
+
+- Seed: `805968`
+- Time: `2025-08-29T21:48:07.544816+00:00`
+- Epochs: `10`
+- Duration/epoch: `600 s`
+- Total checks: `10`
+- Consistent: `8`
+- Inconsistent: `2`
+- Score: **80.0 %**
+
+## Inconsistency Breakdown
+- Availability says YES, Dataselect says NO: `0`
+- Availability says NO, Dataselect says YES: `2`
+
+## Dataselect Response Types
+- **NoTrace**: `3`
+- **SingleTrace**: `7`
+
+---
+
+## Detailed Results
+### `1Y.GR24.00.HHE`
+- Window: `2022-11-14T15:20:36 → 2022-11-14T15:30:36`
+- Availability: `False`
+- Dataselect: `False`
+- Type: `NoTrace`
+- Status: `NoData`
+- Consistent: `✔️`
+
+### `HT.KPRO..HHE`
+- Window: `2011-06-29T15:18:22 → 2011-06-29T15:28:22`
+- Availability: `False`
+- Dataselect: `True`
+- Type: `SingleTrace`
+- Status: `OK`
+- Consistent: `❌`
+
+### `EG.MMAA..EN1`
+- Window: `2016-01-09T22:41:18 → 2016-01-09T22:51:18`
+- Availability: `False`
+- Dataselect: `True`
+- Type: `SingleTrace`
+- Status: `OK`
+- Consistent: `❌`
+
+### `HC.THT2..HHZ`
+- Window: `2013-09-18T20:27:47 → 2013-09-18T20:37:47`
+- Availability: `False`
+- Dataselect: `False`
+- Type: `NoTrace`
+- Status: `NoData`
+- Consistent: `✔️`
+
+### `1Y.GR21.00.HHN`
+- Window: `2022-11-02T15:00:15 → 2022-11-02T15:10:15`
+- Availability: `True`
+- Dataselect: `True`
+- Type: `SingleTrace`
+- Status: `OK`
+- Consistent: `✔️`
+
+### `EG.MMAA..EN3`
+- Window: `2018-04-23T23:02:01 → 2018-04-23T23:12:01`
+- Availability: `True`
+- Dataselect: `True`
+- Type: `SingleTrace`
+- Status: `OK`
+- Consistent: `✔️`
+
+### `HL.NISR.00.HNN`
+- Window: `2019-07-18T16:46:54 → 2019-07-18T16:56:54`
+- Availability: `False`
+- Dataselect: `False`
+- Type: `NoTrace`
+- Status: `NoData`
+- Consistent: `✔️`
+
+### `HL.CHNB.00.HNE`
+- Window: `2024-02-12T18:30:19 → 2024-02-12T18:40:19`
+- Availability: `True`
+- Dataselect: `True`
+- Type: `SingleTrace`
+- Status: `OK`
+- Consistent: `✔️`
+
+### `HL.AMGA..HHN`
+- Window: `2025-07-27T21:04:34 → 2025-07-27T21:14:34`
+- Availability: `True`
+- Dataselect: `True`
+- Type: `SingleTrace`
+- Status: `OK`
+- Consistent: `✔️`
+
+### `HP.GUR..HNN`
+- Window: `2019-05-16T07:08:52 → 2019-05-16T07:18:52`
+- Availability: `True`
+- Dataselect: `True`
+- Type: `SingleTrace`
+- Status: `OK`
+- Consistent: `✔️`

--- a/reports/noa_886209_20250829_213905.json
+++ b/reports/noa_886209_20250829_213905.json
@@ -1,0 +1,224 @@
+{
+  "summary": {
+    "node": "NOA",
+    "seed": 886209,
+    "epochs": 10,
+    "duration": 600,
+    "total_checked": 10,
+    "total_consistent": 6,
+    "total_inconsistent": 4,
+    "timestamp": "2025-08-29T21:39:05.568074+00:00"
+  },
+  "results": [
+    {
+      "index": 8,
+      "url": "https://eida.gein.noa.gr/fdsnws/availability/1/query?network=HL&station=IDI&location=*&channel=HHN&start=2010-12-16T00:00:00Z&end=2017-12-19T00:00:00Z&format=json",
+      "network": "HL",
+      "station": "IDI",
+      "channel": "HHN",
+      "location": "",
+      "available": false,
+      "dataselect_success": false,
+      "dataselect_status": "NoData",
+      "dataselect_type": "NoTrace",
+      "consistent": true,
+      "starttime": "2013-12-03T05:56:51",
+      "endtime": "2013-12-03T06:06:51",
+      "debug": "\u274c No waveform bytes (HTTP 204).\nhttps://eida.gein.noa.gr/fdsnws/dataselect/1/query?network=HL&station=IDI&location=&channel=HHN&starttime=2013-12-03T05:56:51&endtime=2013-12-03T06:06:51&nodata=204",
+      "matched_span": {
+        "start": null,
+        "end": null,
+        "location": null
+      }
+    },
+    {
+      "index": 7,
+      "url": "https://eida.gein.noa.gr/fdsnws/availability/1/query?network=HI&station=PLN1&location=*&channel=HNE&start=2014-12-13T00:00:00Z&end=2025-08-29T21:39:01.055141&format=json",
+      "network": "HI",
+      "station": "PLN1",
+      "channel": "HNE",
+      "location": "",
+      "available": false,
+      "dataselect_success": true,
+      "dataselect_status": "OK",
+      "dataselect_type": "SingleTrace",
+      "consistent": false,
+      "starttime": "2017-02-08T03:47:07",
+      "endtime": "2017-02-08T03:57:07",
+      "debug": "\u2705 Retrieved 1 trace(s) via ObsPy client.\nHI.PLN1..HNE | 2017-02-08T03:47:07.000000Z - 2017-02-08T03:57:07.000000Z | 100.0 Hz, 60001 samples\nhttps://eida.gein.noa.gr/fdsnws/dataselect/1/query?network=HI&station=PLN1&location=&channel=HNE&starttime=2017-02-08T03:47:07&endtime=2017-02-08T03:57:07&nodata=204",
+      "matched_span": {
+        "start": null,
+        "end": null,
+        "location": null
+      }
+    },
+    {
+      "index": 4,
+      "url": "https://eida.gein.noa.gr/fdsnws/availability/1/query?network=HT&station=ALN&location=*&channel=HHN&start=2010-11-24T00:00:00Z&end=2014-05-24T00:00:00Z&format=json",
+      "network": "HT",
+      "station": "ALN",
+      "channel": "HHN",
+      "location": "",
+      "available": false,
+      "dataselect_success": true,
+      "dataselect_status": "OK",
+      "dataselect_type": "SingleTrace",
+      "consistent": false,
+      "starttime": "2011-03-23T01:10:57",
+      "endtime": "2011-03-23T01:20:57",
+      "debug": "\u2705 Retrieved 1 trace(s) via ObsPy client.\nHT.ALN..HHN | 2011-03-23T01:10:57.004100Z - 2011-03-23T01:20:57.004100Z | 100.0 Hz, 60001 samples\nhttps://eida.gein.noa.gr/fdsnws/dataselect/1/query?network=HT&station=ALN&location=&channel=HHN&starttime=2011-03-23T01:10:57&endtime=2011-03-23T01:20:57&nodata=204",
+      "matched_span": {
+        "start": null,
+        "end": null,
+        "location": null
+      }
+    },
+    {
+      "index": 3,
+      "url": "https://eida.gein.noa.gr/fdsnws/availability/1/query?network=MA&station=OHR&location=*&channel=HNZ&start=2025-08-05T14:40:07Z&end=2025-08-29T21:38:56.027235&format=json",
+      "network": "MA",
+      "station": "OHR",
+      "channel": "HNZ",
+      "location": "",
+      "available": true,
+      "dataselect_success": true,
+      "dataselect_status": "OK",
+      "dataselect_type": "MultiTrace",
+      "consistent": true,
+      "starttime": "2025-08-12T02:33:37",
+      "endtime": "2025-08-12T02:43:37",
+      "debug": "\u2705 Retrieved 2 trace(s) via ObsPy client.\nMA.OHR..HNZ | 2025-08-12T02:33:36.999999Z - 2025-08-12T02:43:36.999999Z | 100.0 Hz, 60001 samples\nMA.OHR..HNZ | 2025-08-12T02:33:36.999999Z - 2025-08-12T02:43:36.999999Z | 100.0 Hz, 60001 samples\nhttps://eida.gein.noa.gr/fdsnws/dataselect/1/query?network=MA&station=OHR&location=&channel=HNZ&starttime=2025-08-12T02:33:37&endtime=2025-08-12T02:43:37&nodata=204",
+      "matched_span": {
+        "start": "2025-08-12T00:00:00.000000Z",
+        "end": "2025-08-13T00:00:00.000000Z",
+        "location": ""
+      }
+    },
+    {
+      "index": 2,
+      "url": "https://eida.gein.noa.gr/fdsnws/availability/1/query?network=HI&station=PRE2&location=*&channel=HNN&start=2013-02-01T00:00:00Z&end=2025-08-29T21:38:55.862663&format=json",
+      "network": "HI",
+      "station": "PRE2",
+      "channel": "HNN",
+      "location": "",
+      "available": false,
+      "dataselect_success": false,
+      "dataselect_status": "NoData",
+      "dataselect_type": "NoTrace",
+      "consistent": true,
+      "starttime": "2024-01-22T15:44:15",
+      "endtime": "2024-01-22T15:54:15",
+      "debug": "\u274c No waveform bytes (HTTP 204).\nhttps://eida.gein.noa.gr/fdsnws/dataselect/1/query?network=HI&station=PRE2&location=&channel=HNN&starttime=2024-01-22T15:44:15&endtime=2024-01-22T15:54:15&nodata=204",
+      "matched_span": {
+        "start": null,
+        "end": null,
+        "location": null
+      }
+    },
+    {
+      "index": 5,
+      "url": "https://eida.gein.noa.gr/fdsnws/availability/1/query?network=HL&station=XANC&location=00&channel=HNZ&start=2012-05-03T00:00:00Z&end=2021-06-01T23:59:59Z&format=json",
+      "network": "HL",
+      "station": "XANC",
+      "channel": "HNZ",
+      "location": "00",
+      "available": false,
+      "dataselect_success": true,
+      "dataselect_status": "OK",
+      "dataselect_type": "SingleTrace",
+      "consistent": false,
+      "starttime": "2016-10-17T17:53:29",
+      "endtime": "2016-10-17T18:03:29",
+      "debug": "\u2705 Retrieved 1 trace(s) via ObsPy client.\nHL.XANC.00.HNZ | 2016-10-17T17:53:29.000000Z - 2016-10-17T18:03:29.000000Z | 200.0 Hz, 120001 samples\nhttps://eida.gein.noa.gr/fdsnws/dataselect/1/query?network=HL&station=XANC&location=00&channel=HNZ&starttime=2016-10-17T17:53:29&endtime=2016-10-17T18:03:29&nodata=204",
+      "matched_span": {
+        "start": null,
+        "end": null,
+        "location": null
+      }
+    },
+    {
+      "index": 6,
+      "url": "https://eida.gein.noa.gr/fdsnws/availability/1/query?network=HL&station=RDO&location=*&channel=SHN&start=2008-01-30T00:00:00Z&end=2010-10-29T00:00:00Z&format=json",
+      "network": "HL",
+      "station": "RDO",
+      "channel": "SHN",
+      "location": "",
+      "available": false,
+      "dataselect_success": true,
+      "dataselect_status": "OK",
+      "dataselect_type": "SingleTrace",
+      "consistent": false,
+      "starttime": "2008-06-04T03:27:42",
+      "endtime": "2008-06-04T03:37:42",
+      "debug": "\u2705 Retrieved 1 trace(s) via ObsPy client.\nHL.RDO..SHN | 2008-06-04T03:27:42.000000Z - 2008-06-04T03:37:42.000000Z | 50.0 Hz, 30001 samples\nhttps://eida.gein.noa.gr/fdsnws/dataselect/1/query?network=HL&station=RDO&location=&channel=SHN&starttime=2008-06-04T03:27:42&endtime=2008-06-04T03:37:42&nodata=204",
+      "matched_span": {
+        "start": null,
+        "end": null,
+        "location": null
+      }
+    },
+    {
+      "index": 1,
+      "url": "https://eida.gein.noa.gr/fdsnws/availability/1/query?network=HC&station=TMBK&location=*&channel=HHE&start=2013-04-01T00:00:00Z&end=2019-10-02T14:37:59Z&format=json",
+      "network": "HC",
+      "station": "TMBK",
+      "channel": "HHE",
+      "location": "",
+      "available": true,
+      "dataselect_success": true,
+      "dataselect_status": "OK",
+      "dataselect_type": "SingleTrace",
+      "consistent": true,
+      "starttime": "2017-12-25T17:39:00",
+      "endtime": "2017-12-25T17:49:00",
+      "debug": "\u2705 Retrieved 1 trace(s) via ObsPy client.\nHC.TMBK..HHE | 2017-12-25T17:38:59.999999Z - 2017-12-25T17:48:59.999999Z | 100.0 Hz, 60001 samples\nhttps://eida.gein.noa.gr/fdsnws/dataselect/1/query?network=HC&station=TMBK&location=&channel=HHE&starttime=2017-12-25T17:39:00&endtime=2017-12-25T17:49:00&nodata=204",
+      "matched_span": {
+        "start": "2017-12-25T00:00:00.000000Z",
+        "end": "2017-12-26T00:00:00.000000Z",
+        "location": ""
+      }
+    },
+    {
+      "index": 10,
+      "url": "https://eida.gein.noa.gr/fdsnws/availability/1/query?network=HT&station=TYR2A&location=*&channel=HHZ&start=2021-03-26T08:00:00Z&end=2021-04-30T00:00:00Z&format=json",
+      "network": "HT",
+      "station": "TYR2A",
+      "channel": "HHZ",
+      "location": "",
+      "available": true,
+      "dataselect_success": true,
+      "dataselect_status": "OK",
+      "dataselect_type": "SingleTrace",
+      "consistent": true,
+      "starttime": "2021-04-06T20:38:51",
+      "endtime": "2021-04-06T20:48:51",
+      "debug": "\u2705 Retrieved 1 trace(s) via ObsPy client.\nHT.TYR2A..HHZ | 2021-04-06T20:38:51.000000Z - 2021-04-06T20:48:51.000000Z | 100.0 Hz, 60001 samples\nhttps://eida.gein.noa.gr/fdsnws/dataselect/1/query?network=HT&station=TYR2A&location=&channel=HHZ&starttime=2021-04-06T20:38:51&endtime=2021-04-06T20:48:51&nodata=204",
+      "matched_span": {
+        "start": "2021-04-06T00:00:00.000000Z",
+        "end": "2021-04-07T00:00:00.000000Z",
+        "location": ""
+      }
+    },
+    {
+      "index": 9,
+      "url": "https://eida.gein.noa.gr/fdsnws/availability/1/query?network=HC&station=PASK&location=*&channel=HNZ&start=2015-12-16T00:00:00Z&end=2021-06-09T23:59:00Z&format=json",
+      "network": "HC",
+      "station": "PASK",
+      "channel": "HNZ",
+      "location": "",
+      "available": false,
+      "dataselect_success": false,
+      "dataselect_status": "NoData",
+      "dataselect_type": "NoTrace",
+      "consistent": true,
+      "starttime": "2018-04-25T04:44:58",
+      "endtime": "2018-04-25T04:54:58",
+      "debug": "\u274c No waveform bytes (HTTP 204).\nhttps://eida.gein.noa.gr/fdsnws/dataselect/1/query?network=HC&station=PASK&location=&channel=HNZ&starttime=2018-04-25T04:44:58&endtime=2018-04-25T04:54:58&nodata=204",
+      "matched_span": {
+        "start": null,
+        "end": null,
+        "location": null
+      }
+    }
+  ]
+}

--- a/reports/noa_886209_20250829_213905.md
+++ b/reports/noa_886209_20250829_213905.md
@@ -1,0 +1,100 @@
+# EIDA Consistency Report: `NOA`
+
+- Seed: `886209`
+- Time: `2025-08-29T21:39:05.568074+00:00`
+- Epochs: `10`
+- Duration/epoch: `600 s`
+- Total checks: `10`
+- Consistent: `6`
+- Inconsistent: `4`
+
+## Dataselect Response Types
+- **MultiTrace**: `1`
+- **NoTrace**: `3`
+- **SingleTrace**: `6`
+
+---
+
+## Detailed Results
+### `HL.IDI..HHN`
+- Window: `2013-12-03T05:56:51 → 2013-12-03T06:06:51`
+- Availability: `False`
+- Dataselect: `False`
+- Type: `NoTrace`
+- Status: `NoData`
+- Consistent: `✔️`
+
+### `HI.PLN1..HNE`
+- Window: `2017-02-08T03:47:07 → 2017-02-08T03:57:07`
+- Availability: `False`
+- Dataselect: `True`
+- Type: `SingleTrace`
+- Status: `OK`
+- Consistent: `❌`
+
+### `HT.ALN..HHN`
+- Window: `2011-03-23T01:10:57 → 2011-03-23T01:20:57`
+- Availability: `False`
+- Dataselect: `True`
+- Type: `SingleTrace`
+- Status: `OK`
+- Consistent: `❌`
+
+### `MA.OHR..HNZ`
+- Window: `2025-08-12T02:33:37 → 2025-08-12T02:43:37`
+- Availability: `True`
+- Dataselect: `True`
+- Type: `MultiTrace`
+- Status: `OK`
+- Consistent: `✔️`
+- Matched span: `2025-08-12T00:00:00.000000Z → 2025-08-13T00:00:00.000000Z`
+
+### `HI.PRE2..HNN`
+- Window: `2024-01-22T15:44:15 → 2024-01-22T15:54:15`
+- Availability: `False`
+- Dataselect: `False`
+- Type: `NoTrace`
+- Status: `NoData`
+- Consistent: `✔️`
+
+### `HL.XANC.00.HNZ`
+- Window: `2016-10-17T17:53:29 → 2016-10-17T18:03:29`
+- Availability: `False`
+- Dataselect: `True`
+- Type: `SingleTrace`
+- Status: `OK`
+- Consistent: `❌`
+
+### `HL.RDO..SHN`
+- Window: `2008-06-04T03:27:42 → 2008-06-04T03:37:42`
+- Availability: `False`
+- Dataselect: `True`
+- Type: `SingleTrace`
+- Status: `OK`
+- Consistent: `❌`
+
+### `HC.TMBK..HHE`
+- Window: `2017-12-25T17:39:00 → 2017-12-25T17:49:00`
+- Availability: `True`
+- Dataselect: `True`
+- Type: `SingleTrace`
+- Status: `OK`
+- Consistent: `✔️`
+- Matched span: `2017-12-25T00:00:00.000000Z → 2017-12-26T00:00:00.000000Z`
+
+### `HT.TYR2A..HHZ`
+- Window: `2021-04-06T20:38:51 → 2021-04-06T20:48:51`
+- Availability: `True`
+- Dataselect: `True`
+- Type: `SingleTrace`
+- Status: `OK`
+- Consistent: `✔️`
+- Matched span: `2021-04-06T00:00:00.000000Z → 2021-04-07T00:00:00.000000Z`
+
+### `HC.PASK..HNZ`
+- Window: `2018-04-25T04:44:58 → 2018-04-25T04:54:58`
+- Availability: `False`
+- Dataselect: `False`
+- Type: `NoTrace`
+- Status: `NoData`
+- Consistent: `✔️`

--- a/reports/resif_603028_20250828_153512.json
+++ b/reports/resif_603028_20250828_153512.json
@@ -1,0 +1,224 @@
+{
+  "summary": {
+    "node": "RESIF",
+    "seed": 603028,
+    "epochs": 10,
+    "duration": 600,
+    "total_checked": 10,
+    "total_consistent": 9,
+    "total_inconsistent": 1,
+    "timestamp": "2025-08-28T15:35:12.667581+00:00"
+  },
+  "results": [
+    {
+      "index": 6,
+      "url": "https://ws.resif.fr/fdsnws/availability/1/query?network=6J&station=B39&location=00&channel=DPE&start=2018-07-05T08:21:00&end=2018-07-07T09:30:00&format=json",
+      "network": "6J",
+      "station": "B39",
+      "channel": "DPE",
+      "location": "00",
+      "available": true,
+      "dataselect_success": false,
+      "dataselect_status": "NoData",
+      "dataselect_type": "NoTrace",
+      "consistent": false,
+      "starttime": "2018-07-07T07:10:45",
+      "endtime": "2018-07-07T07:20:45",
+      "debug": "\u274c No waveform bytes (HTTP 204).\nhttps://ws.resif.fr/fdsnws/dataselect/1/query?network=6J&station=B39&location=00&channel=DPE&starttime=2018-07-07T07:10:45&endtime=2018-07-07T07:20:45&nodata=204",
+      "matched_span": {
+        "start": "2018-07-05T08:21:00.000000Z",
+        "end": "2018-07-07T09:30:00.000000Z",
+        "location": "00"
+      }
+    },
+    {
+      "index": 4,
+      "url": "https://ws.resif.fr/fdsnws/availability/1/query?network=G&station=FDF&location=00&channel=LHZ&start=2002-11-27T00:00:00&end=2004-11-22T18:44:00&format=json",
+      "network": "G",
+      "station": "FDF",
+      "channel": "LHZ",
+      "location": "00",
+      "available": true,
+      "dataselect_success": true,
+      "dataselect_status": "OK",
+      "dataselect_type": "SingleTrace",
+      "consistent": true,
+      "starttime": "2003-04-23T23:44:07",
+      "endtime": "2003-04-23T23:54:07",
+      "debug": "\u2705 Retrieved 1 trace(s) via ObsPy client.\nG.FDF.00.LHZ | 2003-04-23T23:44:07.500000Z - 2003-04-23T23:54:06.500000Z | 1.0 Hz, 600 samples\nhttps://ws.resif.fr/fdsnws/dataselect/1/query?network=G&station=FDF&location=00&channel=LHZ&starttime=2003-04-23T23:44:07&endtime=2003-04-23T23:54:07&nodata=204",
+      "matched_span": {
+        "start": "2002-12-31T09:06:01.500000Z",
+        "end": "2004-02-09T11:13:10.500000Z",
+        "location": "00"
+      }
+    },
+    {
+      "index": 1,
+      "url": "https://ws.resif.fr/fdsnws/availability/1/query?network=G&station=SSB&location=*&channel=LHE&start=1990-04-15T00:00:00&end=1994-01-12T00:00:00&format=json",
+      "network": "G",
+      "station": "SSB",
+      "channel": "LHE",
+      "location": "",
+      "available": false,
+      "dataselect_success": false,
+      "dataselect_status": "InternalMSEEDParseTimeError",
+      "dataselect_type": "Error",
+      "consistent": true,
+      "starttime": "1993-10-31T02:07:25",
+      "endtime": "1993-10-31T02:17:25",
+      "debug": "\u274c Dataselect failed (both client and raw).\nhttps://ws.resif.fr/fdsnws/dataselect/1/query?network=G&station=SSB&location=&channel=LHE&starttime=1993-10-31T02:07:25&endtime=1993-10-31T02:17:25&nodata=204",
+      "matched_span": {
+        "start": null,
+        "end": null,
+        "location": null
+      }
+    },
+    {
+      "index": 3,
+      "url": "https://ws.resif.fr/fdsnws/availability/1/query?network=FR&station=LABF&location=00&channel=BHE&start=2021-09-23T15:30:00&end=2023-10-18T08:26:00&format=json",
+      "network": "FR",
+      "station": "LABF",
+      "channel": "BHE",
+      "location": "00",
+      "available": true,
+      "dataselect_success": true,
+      "dataselect_status": "OK",
+      "dataselect_type": "SingleTrace",
+      "consistent": true,
+      "starttime": "2022-06-26T13:24:40",
+      "endtime": "2022-06-26T13:34:40",
+      "debug": "\u2705 Retrieved 1 trace(s) via ObsPy client.\nFR.LABF.00.BHE | 2022-06-26T13:24:40.033000Z - 2022-06-26T13:34:39.983000Z | 20.0 Hz, 12000 samples\nhttps://ws.resif.fr/fdsnws/dataselect/1/query?network=FR&station=LABF&location=00&channel=BHE&starttime=2022-06-26T13:24:40&endtime=2022-06-26T13:34:40&nodata=204",
+      "matched_span": {
+        "start": "2022-06-26T06:51:29.183000Z",
+        "end": "2022-06-26T17:23:44.733000Z",
+        "location": "00"
+      }
+    },
+    {
+      "index": 2,
+      "url": "https://ws.resif.fr/fdsnws/availability/1/query?network=G&station=FDF&location=00&channel=BHE&start=2009-07-10T00:00:00&end=2019-10-21T00:00:00&format=json",
+      "network": "G",
+      "station": "FDF",
+      "channel": "BHE",
+      "location": "00",
+      "available": true,
+      "dataselect_success": true,
+      "dataselect_status": "OK",
+      "dataselect_type": "SingleTrace",
+      "consistent": true,
+      "starttime": "2009-08-07T04:53:52",
+      "endtime": "2009-08-07T05:03:52",
+      "debug": "\u2705 Retrieved 1 trace(s) via ObsPy client.\nG.FDF.00.BHE | 2009-08-07T04:53:52.000000Z - 2009-08-07T05:03:52.000000Z | 20.0 Hz, 12001 samples\nhttps://ws.resif.fr/fdsnws/dataselect/1/query?network=G&station=FDF&location=00&channel=BHE&starttime=2009-08-07T04:53:52&endtime=2009-08-07T05:03:52&nodata=204",
+      "matched_span": {
+        "start": "2009-08-03T00:00:02.600001Z",
+        "end": "2009-08-15T00:00:02.950000Z",
+        "location": "00"
+      }
+    },
+    {
+      "index": 7,
+      "url": "https://ws.resif.fr/fdsnws/availability/1/query?network=FR&station=ANTF&location=00&channel=HHZ&start=2008-10-10T09:11:00&end=2012-06-12T08:01:00&format=json",
+      "network": "FR",
+      "station": "ANTF",
+      "channel": "HHZ",
+      "location": "00",
+      "available": false,
+      "dataselect_success": false,
+      "dataselect_status": "NoData",
+      "dataselect_type": "NoTrace",
+      "consistent": true,
+      "starttime": "2009-05-17T16:55:49",
+      "endtime": "2009-05-17T17:05:49",
+      "debug": "\u274c No waveform bytes (HTTP 204).\nhttps://ws.resif.fr/fdsnws/dataselect/1/query?network=FR&station=ANTF&location=00&channel=HHZ&starttime=2009-05-17T16:55:49&endtime=2009-05-17T17:05:49&nodata=204",
+      "matched_span": {
+        "start": null,
+        "end": null,
+        "location": null
+      }
+    },
+    {
+      "index": 8,
+      "url": "https://ws.resif.fr/fdsnws/availability/1/query?network=RA&station=GLAN&location=00&channel=HNE&start=2018-12-19T17:03:00&end=2021-11-17T08:45:00&format=json",
+      "network": "RA",
+      "station": "GLAN",
+      "channel": "HNE",
+      "location": "00",
+      "available": true,
+      "dataselect_success": true,
+      "dataselect_status": "OK",
+      "dataselect_type": "SingleTrace",
+      "consistent": true,
+      "starttime": "2021-09-18T20:14:02",
+      "endtime": "2021-09-18T20:24:02",
+      "debug": "\u2705 Retrieved 1 trace(s) via ObsPy client.\nRA.GLAN.00.HNE | 2021-09-18T20:14:02.001000Z - 2021-09-18T20:24:01.993000Z | 125.0 Hz, 75000 samples\nhttps://ws.resif.fr/fdsnws/dataselect/1/query?network=RA&station=GLAN&location=00&channel=HNE&starttime=2021-09-18T20:14:02&endtime=2021-09-18T20:24:02&nodata=204",
+      "matched_span": {
+        "start": "2021-09-18T00:00:00.001000Z",
+        "end": "2021-09-18T23:59:58.993000Z",
+        "location": "00"
+      }
+    },
+    {
+      "index": 9,
+      "url": "https://ws.resif.fr/fdsnws/availability/1/query?network=X7&station=PY42A&location=00&channel=HHZ&start=2011-03-21T17:00:00&end=2012-09-07T09:50:00&format=json",
+      "network": "X7",
+      "station": "PY42A",
+      "channel": "HHZ",
+      "location": "00",
+      "available": true,
+      "dataselect_success": true,
+      "dataselect_status": "OK",
+      "dataselect_type": "SingleTrace",
+      "consistent": true,
+      "starttime": "2012-02-02T10:48:14",
+      "endtime": "2012-02-02T10:58:14",
+      "debug": "\u2705 Retrieved 1 trace(s) via ObsPy client.\nX7.PY42A.00.HHZ | 2012-02-02T10:48:14.000000Z - 2012-02-02T10:58:14.000000Z | 100.0 Hz, 60001 samples\nhttps://ws.resif.fr/fdsnws/dataselect/1/query?network=X7&station=PY42A&location=00&channel=HHZ&starttime=2012-02-02T10:48:14&endtime=2012-02-02T10:58:14&nodata=204",
+      "matched_span": {
+        "start": "2012-01-25T10:26:25.610000Z",
+        "end": "2012-02-12T23:59:33.790000Z",
+        "location": "00"
+      }
+    },
+    {
+      "index": 10,
+      "url": "https://ws.resif.fr/fdsnws/availability/1/query?network=6J&station=VZ46&location=00&channel=DPZ&start=2018-07-10T09:05:00&end=2018-07-10T13:30:00&format=json",
+      "network": "6J",
+      "station": "VZ46",
+      "channel": "DPZ",
+      "location": "00",
+      "available": true,
+      "dataselect_success": true,
+      "dataselect_status": "OK",
+      "dataselect_type": "SingleTrace",
+      "consistent": true,
+      "starttime": "2018-07-10T10:06:58",
+      "endtime": "2018-07-10T10:16:58",
+      "debug": "\u2705 Retrieved 1 trace(s) via ObsPy client.\n6J.VZ46.00.DPZ | 2018-07-10T10:06:58.000000Z - 2018-07-10T10:16:58.000000Z | 500.0 Hz, 300001 samples\nhttps://ws.resif.fr/fdsnws/dataselect/1/query?network=6J&station=VZ46&location=00&channel=DPZ&starttime=2018-07-10T10:06:58&endtime=2018-07-10T10:16:58&nodata=204",
+      "matched_span": {
+        "start": "2018-07-10T09:05:00.000000Z",
+        "end": "2018-07-10T13:30:00.000000Z",
+        "location": "00"
+      }
+    },
+    {
+      "index": 5,
+      "url": "https://ws.resif.fr/fdsnws/availability/1/query?network=RA&station=PYAT&location=00&channel=HNZ&start=2006-02-23T10:00:00&end=2007-11-13T09:49:00&format=json",
+      "network": "RA",
+      "station": "PYAT",
+      "channel": "HNZ",
+      "location": "00",
+      "available": false,
+      "dataselect_success": false,
+      "dataselect_status": "NoData",
+      "dataselect_type": "NoTrace",
+      "consistent": true,
+      "starttime": "2006-10-06T20:21:16",
+      "endtime": "2006-10-06T20:31:16",
+      "debug": "\u274c No waveform bytes (HTTP 204).\nhttps://ws.resif.fr/fdsnws/dataselect/1/query?network=RA&station=PYAT&location=00&channel=HNZ&starttime=2006-10-06T20:21:16&endtime=2006-10-06T20:31:16&nodata=204",
+      "matched_span": {
+        "start": null,
+        "end": null,
+        "location": null
+      }
+    }
+  ]
+}

--- a/reports/resif_603028_20250828_153512.md
+++ b/reports/resif_603028_20250828_153512.md
@@ -1,0 +1,104 @@
+# EIDA Consistency Report: `RESIF`
+
+- Seed: `603028`
+- Time: `2025-08-28T15:35:12.667581+00:00`
+- Epochs: `10`
+- Duration/epoch: `600 s`
+- Total checks: `10`
+- Consistent: `9`
+- Inconsistent: `1`
+
+## Dataselect Response Types
+- **Error**: `1`
+- **NoTrace**: `3`
+- **SingleTrace**: `6`
+
+---
+
+## Detailed Results
+### `6J.B39.00.DPE`
+- Window: `2018-07-07T07:10:45 → 2018-07-07T07:20:45`
+- Availability: `True`
+- Dataselect: `False`
+- Type: `NoTrace`
+- Status: `NoData`
+- Consistent: `❌`
+- Matched span: `2018-07-05T08:21:00.000000Z → 2018-07-07T09:30:00.000000Z` (loc=00)
+
+### `G.FDF.00.LHZ`
+- Window: `2003-04-23T23:44:07 → 2003-04-23T23:54:07`
+- Availability: `True`
+- Dataselect: `True`
+- Type: `SingleTrace`
+- Status: `OK`
+- Consistent: `✔️`
+- Matched span: `2002-12-31T09:06:01.500000Z → 2004-02-09T11:13:10.500000Z` (loc=00)
+
+### `G.SSB..LHE`
+- Window: `1993-10-31T02:07:25 → 1993-10-31T02:17:25`
+- Availability: `False`
+- Dataselect: `False`
+- Type: `Error`
+- Status: `InternalMSEEDParseTimeError`
+- Consistent: `✔️`
+
+### `FR.LABF.00.BHE`
+- Window: `2022-06-26T13:24:40 → 2022-06-26T13:34:40`
+- Availability: `True`
+- Dataselect: `True`
+- Type: `SingleTrace`
+- Status: `OK`
+- Consistent: `✔️`
+- Matched span: `2022-06-26T06:51:29.183000Z → 2022-06-26T17:23:44.733000Z` (loc=00)
+
+### `G.FDF.00.BHE`
+- Window: `2009-08-07T04:53:52 → 2009-08-07T05:03:52`
+- Availability: `True`
+- Dataselect: `True`
+- Type: `SingleTrace`
+- Status: `OK`
+- Consistent: `✔️`
+- Matched span: `2009-08-03T00:00:02.600001Z → 2009-08-15T00:00:02.950000Z` (loc=00)
+
+### `FR.ANTF.00.HHZ`
+- Window: `2009-05-17T16:55:49 → 2009-05-17T17:05:49`
+- Availability: `False`
+- Dataselect: `False`
+- Type: `NoTrace`
+- Status: `NoData`
+- Consistent: `✔️`
+
+### `RA.GLAN.00.HNE`
+- Window: `2021-09-18T20:14:02 → 2021-09-18T20:24:02`
+- Availability: `True`
+- Dataselect: `True`
+- Type: `SingleTrace`
+- Status: `OK`
+- Consistent: `✔️`
+- Matched span: `2021-09-18T00:00:00.001000Z → 2021-09-18T23:59:58.993000Z` (loc=00)
+
+### `X7.PY42A.00.HHZ`
+- Window: `2012-02-02T10:48:14 → 2012-02-02T10:58:14`
+- Availability: `True`
+- Dataselect: `True`
+- Type: `SingleTrace`
+- Status: `OK`
+- Consistent: `✔️`
+- Matched span: `2012-01-25T10:26:25.610000Z → 2012-02-12T23:59:33.790000Z` (loc=00)
+
+### `6J.VZ46.00.DPZ`
+- Window: `2018-07-10T10:06:58 → 2018-07-10T10:16:58`
+- Availability: `True`
+- Dataselect: `True`
+- Type: `SingleTrace`
+- Status: `OK`
+- Consistent: `✔️`
+- Matched span: `2018-07-10T09:05:00.000000Z → 2018-07-10T13:30:00.000000Z` (loc=00)
+
+### `RA.PYAT.00.HNZ`
+- Window: `2006-10-06T20:21:16 → 2006-10-06T20:31:16`
+- Availability: `False`
+- Dataselect: `False`
+- Type: `NoTrace`
+- Status: `NoData`
+- Consistent: `✔️`

--- a/src/eida_consistency/cli.py
+++ b/src/eida_consistency/cli.py
@@ -5,8 +5,9 @@ Examples
 $ eida-consistency --log-level DEBUG consistency --node NOA --epochs 5
 $ eida-consistency compare report1.json report2.json
 $ eida-consistency consistency --delete-old
-
+$ eida-consistency explore --latest --index 7 --index 8
 """
+
 import logging
 from pathlib import Path
 
@@ -14,21 +15,11 @@ import click
 from eida_consistency.runner import run_consistency_check
 from eida_consistency.report.compare import compare_reports
 from eida_consistency.report.report import delete_old_reports, REPORT_DIR
+from eida_consistency.explorer import explore_boundaries
 
 
 def normalize_log_level(level: str) -> int:
-    """Normalize a log level string to its numeric value or raise on invalid.
-
-    Parameters
-    ----------
-    level: str
-        Log level name such as "DEBUG", "INFO", "WARNING", "ERROR".
-
-    Returns
-    -------
-    int
-        The numeric logging level (e.g., logging.INFO).
-    """
+    """Normalize a log level string to its numeric value or raise on invalid."""
     numeric = getattr(logging, str(level).upper(), None)
     if not isinstance(numeric, int):
         raise click.BadParameter(f"Invalid log level: {level}")
@@ -108,6 +99,32 @@ def consistency(node, epochs, duration, seed, delete_old, print_stdout):
 def compare(report1, report2):
     """Compare two JSON report files."""
     compare_reports(str(report1), str(report2))
+
+
+@cli.command()
+@click.argument("report", type=click.Path(exists=True, path_type=Path), required=False)
+@click.option(
+    "--index",
+    type=str,
+    callback=lambda _, __, value: [int(x) for x in value.split(",")] if value else None,
+    help="Comma-separated indices of inconsistent tests (e.g. 7,8).",
+)
+@click.option(
+    "--latest",
+    is_flag=True,
+    help="Use the most recent report automatically.",
+)
+def explore(report, index, latest):
+    """Explore day-by-day boundaries of inconsistencies from a report."""
+    if not report:
+        try:
+            report = max(REPORT_DIR.glob("*.json"), key=lambda p: p.stat().st_mtime)
+            logging.info(f"Using latest report: {report}")
+        except ValueError:
+            raise click.UsageError("No report files found in reports/ directory.")
+
+    indices = list(index) if index else None
+    explore_boundaries(report, indices)
 
 
 if __name__ == "__main__":

--- a/src/eida_consistency/core/checker.py
+++ b/src/eida_consistency/core/checker.py
@@ -1,14 +1,20 @@
-"""Pick random epochs and check availability coverage (returns location).
+"""Pick random epochs and check availability coverage (returns location and matched span).
 
 This module selects up to `epochs` unique (network, station, channel) items from the
-candidate pool, places a random epoch of length `duration` within each channel's lifetime,
-and queries /availability/1/query?format=json to determine if the epoch is fully covered.
-If a covering span is found, we prefer its exact location code for the later dataselect
-request (to avoid wildcards and MultiTrace).
+candidate pool. For each channel, it queries /availability/1/query?format=json once for
+the entire epoch-span (from StationXML). Then, within that span, it picks random test
+epochs of length `duration` seconds.
 
 Return value (list of tuples):
     [
-      (availability_url, availability_ok, epoch_start_iso, epoch_end_iso, location_exact),
+      (
+        availability_url,    # the availability request URL (full epoch-span)
+        availability_ok,     # True/False depending on slice coverage
+        epoch_start_iso,     # slice start
+        epoch_end_iso,       # slice end
+        location_exact,      # location code (from matched span or StationXML)
+        matched_span         # the span dict that covered the slice (or None)
+      ),
       ...
     ]
 """
@@ -19,11 +25,11 @@ import random
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 
-from eida_consistency.services.availability import check_availability_query
+from eida_consistency.services.availability import get_availability_spans
 
 
 def _parse_iso(dt: Optional[str]) -> Optional[datetime]:
-    """Parse an ISO-8601 string (tolerate trailing 'Z'). Return None on failure/empty."""
+    """Parse an ISO-8601 string (tolerate trailing 'Z')."""
     if not dt or not str(dt).strip():
         return None
     try:
@@ -32,13 +38,29 @@ def _parse_iso(dt: Optional[str]) -> Optional[datetime]:
         return None
 
 
+def _inside_any_span(
+    t0: datetime, t1: datetime, spans: List[Dict[str, str]]
+) -> Tuple[bool, Dict[str, str] | None]:
+    """Check if [t0, t1] is fully covered by any availability span."""
+    for s in spans:
+        try:
+            s_start, s_end = _parse_iso(s["start"]), _parse_iso(s["end"])
+        except Exception:
+            continue
+        if not s_start or not s_end:
+            continue
+        if s_start <= t0 and s_end >= t1:
+            return True, s
+    return False, None
+
+
 def check_candidate(
     base_url: str,
     candidate: Dict[str, str],
     candidates: Optional[List[Dict[str, str]]] = None,
     epochs: int = 10,
     duration: int = 600,
-) -> List[Tuple[str, bool, str, str, str]]:
+) -> List[Tuple[str, bool, str, str, str, Dict[str, str] | None]]:
     """
     Build up to `epochs` test cases and check availability coverage.
 
@@ -52,22 +74,21 @@ def check_candidate(
     candidates : list[dict] | None
         Full pool of candidates. If None, only `candidate` is used.
     epochs : int
-        Number of unique channels (NET,STA,CHA) to sample.
+        Number of test cases to generate.
     duration : int
-        Duration of each test epoch in seconds. Must be >= 600 (10 minutes).
+        Duration of each test epoch in seconds (default: 600).
 
     Returns
     -------
-    list[tuple[str, bool, str, str, str]]
-        For each tested epoch:
-        (availability_url, availability_ok, epoch_start_iso, epoch_end_iso, location_exact)
+    list of tuples
+        (availability_url, availability_ok, epoch_start_iso, epoch_end_iso,
+         location_exact, matched_span)
     """
     if duration < 600:
         raise ValueError("Duration must be at least 600 seconds (10 minutes).")
 
-    results: List[Tuple[str, bool, str, str, str]] = []
+    results: List[Tuple[str, bool, str, str, str, Dict[str, str] | None]] = []
 
-    # Ensure we have a usable pool
     pool = [
         c for c in (candidates or [candidate])
         if all(k in c for k in ("network", "station", "channel", "starttime"))
@@ -75,11 +96,8 @@ def check_candidate(
     if not pool:
         return results
 
-    used: set[tuple[str, str, str]] = set()  # enforce uniqueness by (NET, STA, CHA)
-
-    # Avoid infinite loops if many candidates are invalid/too short
-    max_attempts = max(epochs * 20, len(pool) * 2)
-    attempts = 0
+    used: set[tuple[str, str, str]] = set()
+    attempts, max_attempts = 0, max(epochs * 20, len(pool) * 2)
 
     while len(results) < epochs and attempts < max_attempts:
         attempts += 1
@@ -88,45 +106,50 @@ def check_candidate(
         if key in used:
             continue
 
-        # Channel lifetime bounds
         ch_start = _parse_iso(sample.get("starttime"))
         ch_end = _parse_iso(sample.get("endtime")) or datetime.utcnow()
-        if not ch_start or not ch_end:
+        if not ch_start or not ch_end or ch_start >= ch_end:
             continue
 
-        # Require at least `duration` seconds of lifetime
-        if (ch_end - ch_start).total_seconds() < duration:
+        # Fetch availability spans once for this channel epoch-span
+        spans = get_availability_spans(
+            base_url,
+            sample["network"],
+            sample["station"],
+            sample["channel"],
+            sample["starttime"],
+            sample.get("endtime") or datetime.utcnow().isoformat(),
+            location=sample.get("location", "*"),
+        )
+        if not spans:
             continue
 
-        # Latest valid start time to fit the full epoch
-        latest_start = ch_end - timedelta(seconds=duration)
+        # Random slice of `duration` seconds inside [ch_start, ch_end]
+        duration_td = timedelta(seconds=duration)
+        latest_start = ch_end - duration_td
         if ch_start >= latest_start:
             continue
 
-        # Pick a random epoch within [ch_start, ch_end - duration]
-        seconds_span = int((latest_start - ch_start).total_seconds())
-        epoch_start_dt = ch_start + timedelta(seconds=random.randint(0, seconds_span))
-        epoch_end_dt = epoch_start_dt + timedelta(seconds=duration)
+        offset = random.randint(0, int((latest_start - ch_start).total_seconds()))
+        epoch_start_dt = ch_start + timedelta(seconds=offset)
+        epoch_end_dt = epoch_start_dt + duration_td
 
         s = epoch_start_dt.strftime("%Y-%m-%dT%H:%M:%S")
         e = epoch_end_dt.strftime("%Y-%m-%dT%H:%M:%S")
 
-        net, sta, cha = sample["network"], sample["station"], sample["channel"]
+        available, matched_span = _inside_any_span(epoch_start_dt, epoch_end_dt, spans)
+        loc = matched_span["location"] if (matched_span and matched_span.get("location")) else sample.get("location", "")
 
-        # Ask availability /query (JSON) using location="*" to discover the exact location
-        av = check_availability_query(base_url, net, sta, cha, s, e, location="*")
-        available = bool(av.get("ok", False))
+        # Availability request URL (for reproducibility/debugging)
+        url = (
+            f"{base_url}availability/1/query?"
+            f"network={sample['network']}&station={sample['station']}"
+            f"&location={sample.get('location','*')}&channel={sample['channel']}"
+            f"&start={sample['starttime']}&end={sample.get('endtime') or datetime.utcnow().isoformat()}"
+            f"&format=json"
+        )
 
-        # Decide single location to use later with dataselect
-        loc_exact = ""
-        matched_span = av.get("matched_span") or {}
-        if matched_span.get("location"):
-            loc_exact = matched_span["location"]
-        elif sample.get("location"):
-            loc_exact = sample["location"]
-
-        # Accept the test case and mark this (NET,STA,CHA) as used
+        results.append((url, available, s, e, loc, matched_span))
         used.add(key)
-        results.append((av.get("url", ""), available, s, e, loc_exact))
 
     return results

--- a/src/eida_consistency/core/formatter.py
+++ b/src/eida_consistency/core/formatter.py
@@ -1,19 +1,6 @@
 """Formatter module for logging consistency-check results."""     
 
 def format_result(idx, url, available, ds_result, match):
-    """Format the result of a single consistency check for logging output.
-
-    Args:
-        idx (int): Index number of the result (1, 2, 3...).
-        url (str): Availability URL used for this check.
-        available (bool): True if availability said data was present.
-        ds_result (dict): Result from dataselect check.
-        match (dict): Original metadata candidate from inventory.
-
-    Returns:
-        str: Multiline string formatted for printing to terminal/log.
-
-    """
     net = match["network"]
     sta = match["station"]
     cha = match["channel"]
@@ -23,17 +10,25 @@ def format_result(idx, url, available, ds_result, match):
     original_end = match.get("endtime", "?")
 
     log = [f"{idx}. {url}"]
-    log.append(f"     Availability: {'✅' if available else '❌'}")
 
-    # Build the Dataselect status string separately to avoid nested f-strings
+    # Availability result
+    if available:
+        line = "     Availability: ✅ (slice covered by spans)"
+        matched_span = match.get("matched_span")
+        if matched_span:
+            line += f" → {matched_span['start']} → {matched_span['end']}"
+        log.append(line)
+    else:
+        log.append("     Availability: ❌ (slice not covered)")
+
+    # Dataselect result
     dataselect_status = "✅" if ds_result["success"] else f"❌ ({ds_result['status']})"
     log.append(f"     Dataselect:   {dataselect_status}")
 
     consistent = available == ds_result["success"]
     log.append(f"     Consistent:   {'✅' if consistent else '❌'}")
-    log.append(f"     Station span: {original_start} → {original_end}")
+    log.append(f"     Epoch span: {original_start} → {original_end}")
 
-    # Optional debug line
     debug = ds_result.get("debug", "").strip()
     if debug:
         log.append(debug)

--- a/src/eida_consistency/explorer.py
+++ b/src/eida_consistency/explorer.py
@@ -1,0 +1,141 @@
+"""Explore inconsistency boundaries around reported results."""
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List, Optional
+
+from eida_consistency.services.availability import get_availability_spans
+from eida_consistency.services.dataselect import dataselect
+from eida_consistency.utils.nodes import load_node_url
+
+
+def _parse_iso(s: str) -> datetime:
+    """Parse ISO string into UTC-aware datetime."""
+    if not s:
+        return None
+    dt = datetime.fromisoformat(str(s).replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    """Format datetime as UTC ISO string (second precision)."""
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def _slice_consistent(base_url: str, net: str, sta: str, cha: str, loc: str,
+                      t0: datetime, t1: datetime) -> bool:
+    """
+    Check if a time slice is consistent between availability and dataselect.
+    Returns True if consistent, False if inconsistent.
+    """
+    # 1. Get availability spans for this slice
+    spans = get_availability_spans(
+        base_url, net, sta, cha, _iso(t0), _iso(t1), location=loc or "*"
+    )
+    covered = any(
+        _parse_iso(s["start"]) <= t0 and _parse_iso(s["end"]) >= t1
+        for s in spans
+    )
+
+    # 2. Fetch dataselect for the same slice
+    ds = dataselect(base_url, net, sta, cha, _iso(t0), _iso(t1), loc)
+
+    # 3. Compare
+    return covered == ds["success"]
+
+
+def explore_boundaries(report_path: str | Path, indices: Optional[List[int]] = None,
+                       max_days: int = 30) -> None:
+    """
+    Explore inconsistencies from a report.
+    If indices is None, explores all inconsistent entries.
+
+    Parameters
+    ----------
+    report_path : str | Path
+        Path to JSON report file.
+    indices : list[int] | None
+        Indices to explore (default: all inconsistent results).
+    max_days : int
+        Maximum days to explore backward and forward (default: 30).
+    """
+    report = json.loads(Path(report_path).read_text())
+    results = report["results"]
+
+    # Filter results
+    if indices:
+        targets = [r for r in results if r["index"] in indices]
+    else:
+        targets = [r for r in results if not r["consistent"]]
+
+    if not targets:
+        logging.info("No targets to explore (all consistent or no matching index).")
+        return
+
+    node = report["summary"]["node"]
+    base_url = load_node_url(node)
+
+    for r in targets:
+        net, sta, cha, loc = r["network"], r["station"], r["channel"], r["location"]
+        slice_start = _parse_iso(r["starttime"])
+        slice_end = _parse_iso(r["endtime"])
+
+        logging.info(
+            f"🔍 Exploring inconsistency for {net}.{sta}.{loc}.{cha} "
+            f"(index={r['index']}) around {slice_start} → {slice_end}"
+        )
+
+        # --- Walk backward by full days ---
+        back = slice_start.date()
+        checked = 0
+        while checked < max_days:
+            prev_day = back - timedelta(days=1)
+            t0 = datetime.combine(prev_day, datetime.min.time(), tzinfo=timezone.utc)
+            t1 = datetime.combine(prev_day, datetime.max.time(), tzinfo=timezone.utc)
+
+            logging.info(f"  ⏳ Checking previous day {prev_day}")
+
+            if _slice_consistent(base_url, net, sta, cha, loc, t0, t1):
+                break
+            back = prev_day
+            checked += 1
+        else:
+            logging.warning(f"⚠️ Reached max backward search limit ({max_days} days).")
+
+        # --- Walk forward by full days ---
+        forward = slice_end.date()
+        checked = 0
+        while checked < max_days:
+            next_day = forward + timedelta(days=1)
+            t0 = datetime.combine(next_day, datetime.min.time(), tzinfo=timezone.utc)
+            t1 = datetime.combine(next_day, datetime.max.time(), tzinfo=timezone.utc)
+
+            logging.info(f"  ⏳ Checking next day {next_day}")
+
+            if _slice_consistent(base_url, net, sta, cha, loc, t0, t1):
+                break
+            forward = next_day
+            checked += 1
+        else:
+            logging.warning(f"⚠️ Reached max forward search limit ({max_days} days).")
+
+        # Report the expanded window
+        logging.info(f"❌ Inconsistency window: {back} → {forward}")
+
+        # Decide which command to suggest
+        if r["available"] and not r["dataselect_success"]:
+            cmd = "clean"
+        elif not r["available"] and r["dataselect_success"]:
+            cmd = "refresh"
+        else:
+            cmd = "refresh"   # fallback
+
+        logging.info(
+            "Suggested command:\n"
+            f"uvx dmtri {cmd} --network={net} --station={sta} --channel={cha} "
+            f"--start={back} --end={forward}"
+        )

--- a/src/eida_consistency/report/report.py
+++ b/src/eida_consistency/report/report.py
@@ -19,15 +19,32 @@ def create_report_object(
     node: str, seed: int, epochs: int, duration: int, records: List[Dict[str, Any]]
 ) -> Dict[str, Any]:
     """Build a serialisable dictionary summarising a full run."""
+
+    total_checked = len(records)
+    total_consistent = sum(1 for r in records if r["consistent"])
+    total_inconsistent = total_checked - total_consistent
+    score = (total_consistent / total_checked * 100.0) if total_checked > 0 else 0.0
+
+    # Breakdown by inconsistency type
+    avail_yes_ds_no = sum(
+        1 for r in records if r["available"] and not r["dataselect_success"]
+    )
+    avail_no_ds_yes = sum(
+        1 for r in records if (not r["available"]) and r["dataselect_success"]
+    )
+
     return {
         "summary": {
             "node": node,
             "seed": seed,
             "epochs": epochs,
             "duration": duration,
-            "total_checked": len(records),
-            "total_consistent": sum(1 for r in records if r["consistent"]),
-            "total_inconsistent": sum(1 for r in records if not r["consistent"]),
+            "total_checked": total_checked,
+            "total_consistent": total_consistent,
+            "total_inconsistent": total_inconsistent,
+            "score": round(score, 2),
+            "availability_yes_dataselect_no": avail_yes_ds_no,
+            "availability_no_dataselect_yes": avail_no_ds_yes,
             "timestamp": datetime.now(timezone.utc).isoformat(),
         },
         "results": records,
@@ -35,10 +52,7 @@ def create_report_object(
 
 
 def _make_unique_filename(node: str, seed: int, extension: str) -> str:
-    """Create a unique file name for the report.
-
-    The leading underscore marks this as a private helper.
-    """
+    """Create a unique file name for the report."""
     short_time = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
     return f"{node.lower()}_{seed}_{short_time}.{extension}"
 
@@ -85,6 +99,11 @@ def save_report_markdown(report: Dict[str, Any], output_dir: Path = REPORT_DIR) 
         f"- Total checks: `{summary['total_checked']}`",
         f"- Consistent: `{summary['total_consistent']}`",
         f"- Inconsistent: `{summary['total_inconsistent']}`",
+        f"- Score: **{summary['score']} %**",
+        "",
+        "## Inconsistency Breakdown",
+        f"- Availability says YES, Dataselect says NO: `{summary['availability_yes_dataselect_no']}`",
+        f"- Availability says NO, Dataselect says YES: `{summary['availability_no_dataselect_yes']}`",
         "",
         "## Dataselect Response Types",
         *(f"- **{key}**: `{value}`" for key, value in sorted(type_counts.items())),
@@ -113,16 +132,7 @@ def save_report_markdown(report: Dict[str, Any], output_dir: Path = REPORT_DIR) 
 
 
 def delete_old_reports(report_dir: Path = REPORT_DIR, keep: int = 1) -> None:
-    """
-    Keep only the latest `keep` reports (json+md pairs) and delete older ones.
-
-    Parameters
-    ----------
-    report_dir : Path
-        Directory where reports are saved.
-    keep : int
-        Number of report pairs to keep.
-    """
+    """Keep only the latest `keep` reports (json+md pairs) and delete older ones."""
     if not report_dir.exists():
         return
 

--- a/src/eida_consistency/runner.py
+++ b/src/eida_consistency/runner.py
@@ -17,7 +17,7 @@ from .report.report import create_report_object, save_report_json, save_report_m
 def run_consistency_check(
     node: str,
     epochs: int = 10,
-    duration: int = 60,
+    duration: int = 600,
     seed: int | None = None,
     delete_old: bool = False,
     max_workers: int = 10,
@@ -41,38 +41,60 @@ def run_consistency_check(
     logging.info(f"Total candidates fetched: {len(candidates)}")
     logging.info(f" Picking {epochs} random candidates...\n")
 
-    # each item: (url, available, start, end, loc_exact)
-    results = check_candidate(base_url, candidates[0], candidates=candidates, epochs=epochs)
+    # each item: (url, available, start, end, loc_exact, matched_span)
+    results = check_candidate(
+        base_url,
+        candidates[0],
+        candidates=candidates,
+        epochs=epochs,
+        duration=duration,
+    )
 
     logging.info("▶ Checking availability + dataselect consistency in parallel:\n")
 
     all_logs, all_records = [], []
 
     def worker(args):
-        idx, (url, available, start, end, loc_exact), match = args
+        idx, (url, available, start, end, loc_exact, matched_span), match = args
         loc_final = loc_exact or match.get("location", "")  # exact single location
         ds_result = dataselect(
             base_url,
             match["network"], match["station"], match["channel"],
             start, end, loc_final
         )
-        log = format_result(idx, url, available, ds_result, {**match, "location": loc_final})
+        log = format_result(
+            idx,
+            url,
+            available,
+            ds_result,
+            {**match, "location": loc_final, "matched_span": matched_span},
+        )
         record = {
-            "index": idx, "url": url,
-            "network": match["network"], "station": match["station"],
-            "channel": match["channel"], "location": loc_final,
+            "index": idx,
+            "url": url,
+            "network": match["network"],
+            "station": match["station"],
+            "channel": match["channel"],
+            "location": loc_final,
             "available": available,
             "dataselect_success": ds_result["success"],
             "dataselect_status": ds_result["status"],
             "dataselect_type": ds_result.get("type", "?"),
             "consistent": available == ds_result["success"],
-            "starttime": str(start), "endtime": str(end),
+            "starttime": str(start),
+            "endtime": str(end),
             "debug": ds_result.get("debug", ""),
+            # NEW: include matched availability span
+            "matched_span": {
+                "start": matched_span.get("start") if matched_span else None,
+                "end": matched_span.get("end") if matched_span else None,
+                "location": matched_span.get("location") if matched_span else None,
+            },
         }
         return log, record
 
     args_list = []
-    for idx, (url, available, start, end, loc_exact) in enumerate(results, 1):
+    for idx, (url, available, start, end, loc_exact, matched_span) in enumerate(results, 1):
         try:
             parts = url.split("?")[1].split("&")
             net = next(p.split("=")[1] for p in parts if p.startswith("network="))
@@ -81,11 +103,16 @@ def run_consistency_check(
         except Exception:
             net, sta, cha = "?", "?", "?"
 
-        match = next((c for c in candidates
-                      if c["network"] == net and c["station"] == sta and c["channel"] == cha),
-                     None)
+        match = next(
+            (
+                c
+                for c in candidates
+                if c["network"] == net and c["station"] == sta and c["channel"] == cha
+            ),
+            None,
+        )
         if match:
-            args_list.append((idx, (url, available, start, end, loc_exact), match))
+            args_list.append((idx, (url, available, start, end, loc_exact, matched_span), match))
 
     pool_size = max(1, min(max_workers, len(args_list)))
     with concurrent.futures.ThreadPoolExecutor(max_workers=pool_size) as executor:
@@ -98,7 +125,13 @@ def run_consistency_check(
 
     logging.info(f"✅ Collected {len(all_records)} results.")
 
-    report = create_report_object(node=node, seed=seed, epochs=epochs, duration=duration, records=all_records)
+    report = create_report_object(
+        node=node,
+        seed=seed,
+        epochs=epochs,
+        duration=duration,
+        records=all_records,
+    )
     json_path = save_report_json(report)
     md_path = save_report_markdown(report)
     logging.info(f"📁 Report saved to: {json_path}")

--- a/src/eida_consistency/services/availability.py
+++ b/src/eida_consistency/services/availability.py
@@ -4,8 +4,11 @@ Supports both payloads:
 - {"availability": [{"start": "...", "end": "...", ...}, ...]}
 - {"datasources": [{"timespans": [["start","end"], ...], ...}, ...]}
 
-Evaluates if any span fully covers [start, end].
+Functions:
+- check_availability_query() → check if a specific [start,end] is covered (legacy).
+- get_availability_spans() → fetch all spans for a channel in one request (epoch-span).
 """
+
 from __future__ import annotations
 import json
 import logging
@@ -19,6 +22,7 @@ def _parse_iso(s: str) -> datetime:
 
 
 def _collect_spans(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Normalize payload from availability service into a flat list of spans."""
     spans: List[Dict[str, Any]] = []
 
     for r in payload.get("availability", []) or []:
@@ -56,6 +60,7 @@ def check_availability_query(
     endtime: str,
     location: str = "*",
 ) -> Dict[str, Any]:
+    """Legacy: query availability for a specific [start,end] and see if it is covered."""
     url = (
         f"{base_url}availability/1/query?"
         f"network={network}&station={station}&location={location}&channel={channel}"
@@ -65,6 +70,12 @@ def check_availability_query(
 
     try:
         resp = requests.get(url, timeout=20)
+
+        if resp.status_code == 204:
+            logging.debug(f"No availability data for {network}.{station}.{location}.{channel}")
+            return {"ok": False, "matched_span": None, "spans": [], "status": 204, "url": url}
+
+        resp.raise_for_status()
     except Exception as e:
         logging.warning(f"Availability request failed: {e}")
         return {"ok": False, "matched_span": None, "spans": [], "status": 0, "url": url}
@@ -73,38 +84,93 @@ def check_availability_query(
     matched_span: Optional[Dict[str, Any]] = None
     ok = False
 
-    if resp.status_code == 200:
-        try:
-            payload = resp.json()
-            spans = _collect_spans(payload)
+    try:
+        payload = resp.json()
+        spans = _collect_spans(payload)
 
-            # Debug dump (compact)
-            if logging.getLogger().isEnabledFor(logging.DEBUG):
-                try:
-                    pretty = json.dumps(payload, indent=2, ensure_ascii=False)
-                except Exception:
-                    pretty = "<unserializable JSON>"
-                logging.debug(
-                    "[AVAIL DEBUG] URL: %s\n[AVAIL DEBUG] Keys: %s\n[AVAIL DEBUG] Total spans: %d\n%s",
-                    url, list(payload.keys()), len(spans), pretty
-                )
-
-            e_start, e_end = _parse_iso(starttime), _parse_iso(endtime)
-            for s in spans:
-                try:
-                    s_start, s_end = _parse_iso(s["start"]), _parse_iso(s["end"])
-                except Exception:
-                    continue
-                if s_start <= e_start and s_end >= e_end:
-                    ok, matched_span = True, s
-                    break
-        except Exception as e:
-            logging.warning(f"Failed to parse availability JSON: {e}")
-    else:
+        # Debug dump
         if logging.getLogger().isEnabledFor(logging.DEBUG):
-            logging.debug("[AVAIL DEBUG] Non-200 (%s) body:\n%s", resp.status_code, resp.text)
+            try:
+                pretty = json.dumps(payload, indent=2, ensure_ascii=False)
+            except Exception:
+                pretty = "<unserializable JSON>"
+            logging.debug(
+                "[AVAIL DEBUG] URL: %s\n[AVAIL DEBUG] Keys: %s\n[AVAIL DEBUG] Total spans: %d\n%s",
+                url, list(payload.keys()), len(spans), pretty
+            )
+
+        e_start, e_end = _parse_iso(starttime), _parse_iso(endtime)
+        for s in spans:
+            try:
+                s_start, s_end = _parse_iso(s["start"]), _parse_iso(s["end"])
+            except Exception:
+                continue
+            if s_start <= e_start and s_end >= e_end:
+                ok, matched_span = True, s
+                break
+    except Exception as e:
+        logging.warning(f"Failed to parse availability JSON: {e}")
 
     return {"ok": ok, "matched_span": matched_span, "spans": spans, "status": resp.status_code, "url": url}
+
+
+def get_availability_spans(
+    base_url: str,
+    network: str,
+    station: str,
+    channel: str,
+    starttime: str,
+    endtime: str,
+    location: str = "*",
+) -> List[Dict[str, Any]]:
+    """
+    Query availability once for a channel's full epoch-span and return all spans.
+
+    Parameters
+    ----------
+    base_url : str
+        FDSN base URL, e.g. "https://ws.resif.fr/fdsnws/"
+    network, station, channel : str
+        Channel identifiers.
+    starttime, endtime : str
+        Epoch-span (from StationXML candidate).
+    location : str
+        Location code filter (default "*").
+
+    Returns
+    -------
+    list of dict
+        Availability spans with start/end ISO strings and metadata.
+    """
+    url = (
+        f"{base_url}availability/1/query?"
+        f"network={network}&station={station}&location={location}&channel={channel}"
+        f"&start={starttime}&end={endtime}&format=json"
+    )
+    logging.debug(f"Availability (spans) URL: {url}")
+
+    try:
+        resp = requests.get(url, timeout=30)
+
+        if resp.status_code == 204:
+            logging.debug(f"No availability data for {network}.{station}.{location}.{channel}")
+            # Retry once with location="*" if we didn't already
+            if location != "*":
+                logging.debug(f"Retrying with location='*' for {network}.{station}.{channel}")
+                return get_availability_spans(
+                    base_url, network, station, channel, starttime, endtime, location="*"
+                )
+            return []
+
+        resp.raise_for_status()
+        payload = resp.json()
+        spans = _collect_spans(payload)
+        logging.debug(f"Fetched {len(spans)} spans for {network}.{station}.{channel}")
+        return spans
+
+    except Exception as e:
+        logging.error(f"Failed to fetch availability spans: {e}")
+        return []
 
 
 # Back-compat wrapper (keeps older call sites working)

--- a/tests/core/test_checker.py
+++ b/tests/core/test_checker.py
@@ -1,194 +1,177 @@
-# tests/test_checker.py
 import pytest
-from datetime import datetime, timedelta, UTC
-from unittest.mock import patch
+import random
+from datetime import datetime, timedelta
 
 import eida_consistency.core.checker as checker
 
 
-# --------------------------------------------------------------------------- #
-# _parse_iso
-# --------------------------------------------------------------------------- #
+# -------------------------------------------------------------------
+# Helpers
+# -------------------------------------------------------------------
+class DummySpans:
+    """Helper to patch get_availability_spans with controlled responses."""
 
-def test_parse_iso_none_empty_and_invalid():
-    assert checker._parse_iso(None) is None
+    @staticmethod
+    def good(*_a, **_k):
+        # Return a span covering everything
+        return [{
+            "start": "2000-01-01T00:00:00",
+            "end": "2100-01-01T00:00:00",
+            "location": "XX"
+        }]
+
+    @staticmethod
+    def empty(*_a, **_k):
+        return []
+
+
+# -------------------------------------------------------------------
+# Tests for _parse_iso
+# -------------------------------------------------------------------
+def test_parse_iso_valid_and_invalid():
+    # Valid
+    dt = checker._parse_iso("2020-01-01T00:00:00")
+    assert isinstance(dt, datetime)
+    # Empty
     assert checker._parse_iso("") is None
-    assert checker._parse_iso("   ") is None
+    # Invalid format string
     assert checker._parse_iso("not-a-date") is None
+    # Bad format to trigger exception inside fromisoformat
+    assert checker._parse_iso("2020-13-99T99:99:99") is None
 
 
-def test_parse_iso_valid_with_and_without_z():
-    dt = datetime(2020, 1, 1, 12, 0, 0)
-    assert checker._parse_iso("2020-01-01T12:00:00") == dt
-    assert checker._parse_iso("2020-01-01T12:00:00Z") == dt
+# -------------------------------------------------------------------
+# Tests for _inside_any_span
+# -------------------------------------------------------------------
+def test_inside_any_span_true_and_false():
+    t0 = datetime(2020, 1, 1, 0, 0, 0)
+    t1 = datetime(2020, 1, 1, 1, 0, 0)
+    spans = [{"start": "2020-01-01T00:00:00", "end": "2020-01-01T02:00:00"}]
+    ok, span = checker._inside_any_span(t0, t1, spans)
+    assert ok and span is not None
+
+    # Outside span
+    spans = [{"start": "2020-01-01T02:00:00", "end": "2020-01-01T03:00:00"}]
+    ok, span = checker._inside_any_span(t0, t1, spans)
+    assert not ok and span is None
 
 
-# --------------------------------------------------------------------------- #
-# check_candidate
-# --------------------------------------------------------------------------- #
+def test_inside_any_span_exception_branch(monkeypatch):
+    def boom(_):
+        raise ValueError("bad date")
 
-@patch("eida_consistency.core.checker.check_availability_query")
-def test_check_candidate_missing_keys_returns_empty(mock_check):
-    candidate = {"network": "XX"}  # missing required keys
-    results = checker.check_candidate("url", candidate)
-    assert results == []
-    mock_check.assert_not_called()
+    monkeypatch.setattr(checker, "_parse_iso", boom)
+
+    t0 = datetime(2020, 1, 1, 0, 0, 0)
+    t1 = datetime(2020, 1, 1, 1, 0, 0)
+    spans = [{"start": "bad", "end": "bad"}]
+
+    ok, span = checker._inside_any_span(t0, t1, spans)
+    assert not ok and span is None
 
 
-@patch("eida_consistency.core.checker.check_availability_query")
-def test_check_candidate_continue_if_start_or_end_invalid(mock_check):
-    # invalid starttime → _parse_iso returns None → triggers "if not start or not end"
-    cand = {
-        "network": "N",
-        "station": "S",
-        "channel": "C",
-        "starttime": "not-a-date",
-        "endtime": datetime.now(UTC).replace(tzinfo=None).isoformat(),
+def test_inside_any_span_missing_start_end():
+    t0 = datetime(2020, 1, 1, 0, 0, 0)
+    t1 = datetime(2020, 1, 1, 1, 0, 0)
+    spans = [{"start": None, "end": None}]
+    ok, span = checker._inside_any_span(t0, t1, spans)
+    assert not ok and span is None
+
+
+# -------------------------------------------------------------------
+# Tests for check_candidate
+# -------------------------------------------------------------------
+def test_check_candidate_basic(monkeypatch):
+    candidate = {
+        "network": "XX", "station": "STA", "channel": "BHZ",
+        "starttime": "2020-01-01T00:00:00",
+        "endtime": "2020-01-02T00:00:00",
+        "location": "00",
     }
-    results = checker.check_candidate("url", cand, epochs=1)
-    assert results == []
-    mock_check.assert_not_called()
-
-
-@patch("eida_consistency.core.checker.check_availability_query")
-def test_check_candidate_skips_short_duration(mock_check):
-    start = datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=5)
-    cand = {
-        "network": "N",
-        "station": "S",
-        "channel": "C",
-        "starttime": start.isoformat(),
-        "endtime": datetime.now(UTC).replace(tzinfo=None).isoformat(),
-    }
-    results = checker.check_candidate("url", cand, epochs=1)
-    assert results == []
-    mock_check.assert_not_called()
-
-
-@patch("eida_consistency.core.checker.check_availability_query")
-def test_check_candidate_continue_if_start_ge_latest_start(mock_check):
-    # start >= end - 10 minutes → triggers that continue
-    now = datetime.now(UTC).replace(tzinfo=None)
-    start = now - timedelta(minutes=5)
-    cand = {
-        "network": "N",
-        "station": "S",
-        "channel": "C",
-        "starttime": start.isoformat(),
-        "endtime": now.isoformat(),
-    }
-    results = checker.check_candidate("url", cand, epochs=1)
-    assert results == []
-    mock_check.assert_not_called()
-
-@patch("eida_consistency.core.checker.check_availability_query")
-def test_check_candidate_continue_if_start_equals_latest_start(mock_check):
-    # end - start = exactly 600s → not caught by the short-duration check
-    # but start == latest_start → triggers the line 59 continue
-    now = datetime.now(UTC).replace(tzinfo=None)
-    start = now - timedelta(seconds=600)
-    cand = {
-        "network": "N",
-        "station": "S",
-        "channel": "C",
-        "starttime": start.isoformat(),
-        "endtime": now.isoformat(),
-    }
-
-    results = checker.check_candidate("url", cand, epochs=1)
-    assert results == []
-    mock_check.assert_not_called()
-
-@patch("eida_consistency.core.checker.check_availability_query")
-def test_check_candidate_valid_with_matched_span(mock_check):
-    now = datetime.now(UTC).replace(tzinfo=None)
-    start = now - timedelta(hours=2)
-    end = now
-
-    cand = {
-        "network": "N",
-        "station": "S",
-        "channel": "C",
-        "starttime": start.isoformat(),
-        "endtime": end.isoformat(),
-    }
-
-    mock_check.return_value = {
-        "ok": True,
-        "url": "fake-url",
-        "matched_span": {"location": "LOC1"},
-    }
-
-    with patch("random.choice", side_effect=lambda seq: seq[0]), \
-         patch("random.randint", return_value=0):
-        results = checker.check_candidate("base", cand, epochs=1)
-
+    monkeypatch.setattr(checker, "get_availability_spans", DummySpans.good)
+    results = checker.check_candidate("http://fake/", candidate, epochs=1, duration=600)
     assert len(results) == 1
-    url, available, s, e, loc = results[0]
-    assert url == "fake-url"
-    assert available is True
-    assert loc == "LOC1"
+    url, available, s, e, loc, span = results[0]
+    assert url.startswith("http://fake/availability/1/query?")
+    assert available
+    assert loc == "XX"
+    assert span is not None
 
 
-@patch("eida_consistency.core.checker.check_availability_query")
-def test_check_candidate_uses_candidate_location(mock_check):
-    now = datetime.now(UTC).replace(tzinfo=None)
-    start = now - timedelta(hours=2)
-    cand = {
-        "network": "N",
-        "station": "S",
-        "channel": "C",
-        "starttime": start.isoformat(),
-        "location": "CAND_LOC",
+def test_check_candidate_duration_too_short(monkeypatch):
+    candidate = {
+        "network": "XX", "station": "STA", "channel": "BHZ",
+        "starttime": "2020-01-01T00:00:00",
+        "endtime": "2020-01-01T00:01:00",  # less than 600s
     }
-
-    mock_check.return_value = {"ok": False, "url": "url2"}
-
-    with patch("random.choice", side_effect=lambda seq: seq[0]), \
-         patch("random.randint", return_value=0):
-        results = checker.check_candidate("base", cand, epochs=1)
-
-    assert results[0][1] is False
-    assert results[0][4] == "CAND_LOC"
+    monkeypatch.setattr(checker, "get_availability_spans", DummySpans.good)
+    results = checker.check_candidate("http://fake/", candidate, epochs=1, duration=600)
+    assert results == []
 
 
-@patch("eida_consistency.core.checker.check_availability_query")
-def test_check_candidate_location_empty_if_no_info(mock_check):
-    now = datetime.now(UTC).replace(tzinfo=None)
-    start = now - timedelta(hours=2)
-    cand = {
-        "network": "N",
-        "station": "S",
-        "channel": "C",
-        "starttime": start.isoformat(),
+def test_check_candidate_no_spans(monkeypatch):
+    candidate = {
+        "network": "XX", "station": "STA", "channel": "BHZ",
+        "starttime": "2020-01-01T00:00:00",
+        "endtime": "2020-02-01T00:00:00",
     }
-
-    mock_check.return_value = {"ok": True, "url": "url3"}
-
-    with patch("random.choice", side_effect=lambda seq: seq[0]), \
-         patch("random.randint", return_value=0):
-        results = checker.check_candidate("base", cand, epochs=1)
-
-    assert results[0][4] == ""
+    monkeypatch.setattr(checker, "get_availability_spans", DummySpans.empty)
+    results = checker.check_candidate("http://fake/", candidate, epochs=1, duration=600)
+    assert results == []
 
 
-@patch("eida_consistency.core.checker.check_availability_query")
-def test_check_candidate_respects_used_keys(mock_check):
-    now = datetime.now(UTC).replace(tzinfo=None)
-    start = now - timedelta(hours=2)
-    cand = {
-        "network": "N",
-        "station": "S",
-        "channel": "C",
-        "starttime": start.isoformat(),
-        "endtime": now.isoformat(),
+def test_check_candidate_ch_start_ge_latest_start(monkeypatch):
+    candidate = {
+        "network": "XX", "station": "STA", "channel": "BHZ",
+        "starttime": "2020-01-01T00:00:00",
+        "endtime": "2020-01-01T00:09:59",  # shorter than duration
     }
+    monkeypatch.setattr(checker, "get_availability_spans", DummySpans.good)
+    results = checker.check_candidate("http://fake/", candidate, epochs=1, duration=600)
+    assert results == []
 
-    mock_check.return_value = {"ok": True, "url": "url"}
 
-    # epochs > pool → triggers duplicate key skip
-    with patch("random.choice", side_effect=lambda seq: seq[0]), \
-         patch("random.randint", return_value=0):
-        results = checker.check_candidate("base", cand, epochs=2)
-
+def test_check_candidate_duplicate_keys(monkeypatch):
+    candidates = [
+        {
+            "network": "XX", "station": "STA", "channel": "BHZ",
+            "starttime": "2020-01-01T00:00:00",
+            "endtime": "2020-01-02T00:00:00",
+        },
+        {
+            "network": "XX", "station": "STA", "channel": "BHZ",  # duplicate key
+            "starttime": "2020-01-01T00:00:00",
+            "endtime": "2020-01-02T00:00:00",
+        },
+    ]
+    monkeypatch.setattr(checker, "get_availability_spans", DummySpans.good)
+    results = checker.check_candidate("http://fake/", candidates[0], candidates=candidates, epochs=2, duration=600)
+    # Only one unique result, second skipped due to "key in used"
     assert len(results) == 1
+
+
+def test_check_candidate_invalid_dates(monkeypatch):
+    candidate = {
+        "network": "XX", "station": "STA", "channel": "BHZ",
+        "starttime": "bad-date",
+        "endtime": "bad-date",
+    }
+    monkeypatch.setattr(checker, "get_availability_spans", DummySpans.good)
+    results = checker.check_candidate("http://fake/", candidate, epochs=1, duration=600)
+    assert results == []
+
+
+def test_check_candidate_duration_too_small_raises(monkeypatch):
+    candidate = {
+        "network": "XX", "station": "STA", "channel": "BHZ",
+        "starttime": "2020-01-01T00:00:00",
+        "endtime": "2020-01-02T00:00:00",
+    }
+    with pytest.raises(ValueError, match="Duration must be at least 600"):
+        checker.check_candidate("http://fake/", candidate, epochs=1, duration=100)
+
+
+def test_check_candidate_empty_pool(monkeypatch):
+    candidate = {"foo": "bar"}  # missing required keys
+    results = checker.check_candidate("http://fake/", candidate, epochs=1, duration=600)
+    assert results == []

--- a/tests/core/test_formatter.py
+++ b/tests/core/test_formatter.py
@@ -1,66 +1,78 @@
-# tests/test_formatter.py
-import re
 import eida_consistency.core.formatter as formatter
 
 
-def test_format_result_success_consistent_with_debug():
-    ds_result = {"success": True, "status": 200, "debug": "extra-info"}
-    match = {
+def make_match():
+    return {
         "network": "XX",
-        "station": "YY",
-        "channel": "ZZ",
+        "station": "AAA",
+        "channel": "HHZ",
         "location": "00",
-        "starttime": "2020-01-01",
-        "endtime": "2020-01-02",
+        "starttime": "2020-01-01T00:00:00",
+        "endtime": "2020-01-02T00:00:00",
     }
 
-    out = formatter.format_result(1, "http://url", True, ds_result, match)
-    # Should contain ✅ for both availability and dataselect
+
+def test_format_result_consistent_ok():
+    url = "http://fake/query"
+    ds_result = {"success": True, "status": "OK", "debug": "extra-debug"}
+    out = formatter.format_result(1, url, True, ds_result, make_match())
+
+    assert url in out
     assert "Availability: ✅" in out
     assert "Dataselect:   ✅" in out
     assert "Consistent:   ✅" in out
-    assert "extra-info" in out
-    assert out.startswith("1. http://url")
+    assert "Epoch span: 2020-01-01T00:00:00 → 2020-01-02T00:00:00" in out
+    assert "extra-debug" in out
 
 
-def test_format_result_failure_inconsistent_without_debug():
-    ds_result = {"success": False, "status": 500}  # no debug
+def test_format_result_inconsistent_avail_yes_ds_no():
+    url = "http://fake/query"
+    ds_result = {"success": False, "status": "NoData", "debug": ""}
+    out = formatter.format_result(2, url, True, ds_result, make_match())
+
+    assert "Availability: ✅" in out
+    assert "Dataselect:   ❌ (NoData)" in out
+    assert "Consistent:   ❌" in out
+
+
+def test_format_result_inconsistent_avail_no_ds_yes():
+    url = "http://fake/query"
+    ds_result = {"success": True, "status": "OK", "debug": ""}
+    out = formatter.format_result(3, url, False, ds_result, make_match())
+
+    assert "Availability: ❌" in out
+    assert "Dataselect:   ✅" in out
+    assert "Consistent:   ❌" in out
+
+
+def test_format_result_with_missing_location_and_times():
+    url = "http://fake/query"
+    ds_result = {"success": False, "status": "Error", "debug": ""}
     match = {
-        "network": "NN",
-        "station": "SS",
-        "channel": "CC",
-        # omit location and endtime to test fallbacks
-        "starttime": "?", 
+        "network": "YY",
+        "station": "BBB",
+        "channel": "EHN",
+        # no location, no endtime
+        "starttime": "2020-05-01T00:00:00",
+    }
+    out = formatter.format_result(4, url, False, ds_result, match)
+
+    assert "Epoch span: 2020-05-01T00:00:00 → ?" in out
+    assert "Availability: ❌" in out
+    assert "Dataselect:   ❌ (Error)" in out
+
+
+def test_format_result_with_matched_span_includes_start_end():
+    """Ensure matched_span start/end are appended when present in match dict."""
+    url = "http://fake/query"
+    ds_result = {"success": True, "status": "OK", "debug": ""}
+    match = make_match()
+    match["matched_span"] = {
+        "start": "2020-01-01T01:00:00",
+        "end": "2020-01-01T02:00:00",
     }
 
-    out = formatter.format_result(2, "http://bad", True, ds_result, match)
-    # Availability says ✅ but dataselect failed => inconsistency
-    assert "Availability: ✅" in out
-    assert "Dataselect:   ❌ (500)" in out
-    assert "Consistent:   ❌" in out
-    assert "Station span: ? → ?" in out
-    # Ensure no debug line
-    assert "debug" not in out.lower()
+    out = formatter.format_result(5, url, True, ds_result, match)
 
-
-def test_format_result_both_failures_consistent():
-    ds_result = {"success": False, "status": 404}
-    match = {"network": "A", "station": "B", "channel": "C"}
-    out = formatter.format_result(3, "urlX", False, ds_result, match)
-    # Both False → consistency
-    assert "Availability: ❌" in out
-    assert "Dataselect:   ❌ (404)" in out
-    assert "Consistent:   ✅" in out
-
-
-def test_format_result_regex_structure():
-    """Sanity check for multiline format using regex."""
-    ds_result = {"success": True, "status": 200}
-    match = {"network": "N", "station": "S", "channel": "C"}
-    out = formatter.format_result(4, "some-url", True, ds_result, match)
-
-    # 5 lines minimum (idx/url, availability, dataselect, consistent, station span)
-    lines = out.splitlines()
-    assert len(lines) >= 5
-    # first line begins with index and URL
-    assert re.match(r"^4\. some-url$", lines[0])
+    assert "2020-01-01T01:00:00" in out
+    assert "2020-01-01T02:00:00" in out

--- a/tests/report/test_report.py
+++ b/tests/report/test_report.py
@@ -1,111 +1,117 @@
 import json
+import time
 from pathlib import Path
-import re
 
 import pytest
 
-from eida_consistency.report.report import (
-    create_report_object,
-    _make_unique_filename,
-    save_report_json,
-    save_report_markdown,
-)
+import eida_consistency.report.report as report
 
 
-@pytest.fixture
-def sample_records():
+def make_dummy_records():
+    base = {
+        "network": "XX", "station": "AAA", "channel": "HHZ", "location": "00",
+        "starttime": "2020-01-01T00:00:00", "endtime": "2020-01-01T00:10:00",
+    }
     return [
-        {
-            "network": "XX",
-            "station": "AAA",
-            "location": "00",
-            "channel": "BHZ",
-            "starttime": "2020-01-01T00:00:00",
-            "endtime": "2020-01-01T00:10:00",
-            "available": True,
-            "dataselect_success": True,
-            "dataselect_type": "miniseed",
-            "dataselect_status": "200",
-            "consistent": True,
-        },
-        {
-            "network": "XX",
-            "station": "BBB",
-            "location": "",
-            "channel": "BHN",
-            "starttime": "2020-01-01T01:00:00",
-            "endtime": "2020-01-01T01:05:00",
-            "available": False,
-            "dataselect_success": False,
-            "dataselect_status": "404",
-            "consistent": False,
-        },
+        {**base, "consistent": True,  "available": True,  "dataselect_success": True,
+         "dataselect_status": "OK", "dataselect_type": "SingleTrace"},
+        {**base, "consistent": False, "available": True,  "dataselect_success": False,
+         "dataselect_status": "NoData", "dataselect_type": "NoTrace"},
+        {**base, "consistent": False, "available": False, "dataselect_success": True,
+         "dataselect_status": "OK", "dataselect_type": "SingleTrace"},
     ]
 
 
-def test_create_report_object_counts(sample_records):
-    """Check that summary fields are computed correctly."""
-    report = create_report_object("NOA", 123, 5, 60, sample_records)
+def test_create_report_object_score_and_breakdown():
+    recs = make_dummy_records()
+    obj = report.create_report_object("RESIF", seed=123, epochs=3, duration=600, records=recs)
 
-    summary = report["summary"]
-    assert summary["node"] == "NOA"
-    assert summary["seed"] == 123
-    assert summary["epochs"] == 5
-    assert summary["duration"] == 60
-    assert summary["total_checked"] == 2
+    summary = obj["summary"]
+
+    assert summary["node"] == "RESIF"
+    assert summary["total_checked"] == 3
     assert summary["total_consistent"] == 1
-    assert summary["total_inconsistent"] == 1
-    # timestamp must look like an ISO string with timezone
-    assert re.match(r"\d{4}-\d{2}-\d{2}T.*Z?", summary["timestamp"]) or summary["timestamp"].endswith("+00:00")
+    assert summary["total_inconsistent"] == 2
+    # Score = 1/3 * 100 = 33.33
+    assert abs(summary["score"] - 33.33) < 0.01
+    assert summary["availability_yes_dataselect_no"] == 1
+    assert summary["availability_no_dataselect_yes"] == 1
+    assert "timestamp" in summary
 
 
-def test_make_unique_filename_changes_with_time(monkeypatch):
-    """_make_unique_filename should return lowercase node and include timestamp."""
-    import eida_consistency.report as report
-    from datetime import datetime, timezone
+def test_save_report_json_and_load(tmp_path):
+    recs = make_dummy_records()
+    obj = report.create_report_object("NOA", seed=42, epochs=2, duration=600, records=recs)
 
-    fixed_time = datetime(2020, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-
-    class FakeDateTime:
-        @staticmethod
-        def now(tz=None):
-            return fixed_time
-
-    monkeypatch.setattr(report, "datetime", FakeDateTime)
-
-    filename = report._make_unique_filename("NOA", 123, "json")
-    assert filename == "noa_123_20200101_120000.json"
+    path = report.save_report_json(obj, output_dir=tmp_path)
+    assert path.exists()
+    data = json.loads(path.read_text())
+    assert data["summary"]["node"] == "NOA"
 
 
+def test_save_report_markdown_contains_score_and_breakdown(tmp_path):
+    recs = make_dummy_records()
+    obj = report.create_report_object("GFZ", seed=99, epochs=2, duration=600, records=recs)
 
-def test_save_report_json_and_load(tmp_path, sample_records):
-    """save_report_json should write valid JSON that can be read back."""
-    report = create_report_object("GFZ", 42, 2, 120, sample_records)
-    filepath = save_report_json(report, output_dir=tmp_path)
+    path = report.save_report_markdown(obj, output_dir=tmp_path)
+    content = path.read_text()
 
-    assert filepath.exists()
-    with open(filepath) as f:
-        loaded = json.load(f)
-
-    assert loaded["summary"]["node"] == "GFZ"
-    assert loaded["results"][0]["station"] == "AAA"
+    assert "# EIDA Consistency Report" in content
+    assert "Score" in content
+    assert "Inconsistency Breakdown" in content
+    assert "Availability says YES" in content
+    assert "Availability says NO" in content
 
 
-def test_save_report_markdown(tmp_path, sample_records):
-    """save_report_markdown should write a markdown file with key fields."""
-    report = create_report_object("ETH", 99, 3, 300, sample_records)
-    filepath = save_report_markdown(report, output_dir=tmp_path)
+def test_delete_old_reports(tmp_path):
+    recs = make_dummy_records()
+    obj = report.create_report_object("TEST", seed=1, epochs=1, duration=600, records=recs)
 
-    assert filepath.exists()
-    text = filepath.read_text()
+    # Create 3 reports with slight delay so mtime differs
+    for seed in [1, 2, 3]:
+        obj = report.create_report_object("TEST", seed=seed, epochs=1, duration=600, records=recs)
+        report.save_report_json(obj, output_dir=tmp_path)
+        time.sleep(0.05)
 
-    # summary section
-    assert f"# EIDA Consistency Report: `ETH`" in text
-    assert "- Seed: `99`" in text
-    assert "- Epochs: `3`" in text
-    assert "- Duration/epoch: `300 s`" in text
+    # Ensure 3 files exist
+    assert len(list(tmp_path.glob("*.json"))) == 3
 
-    # detailed results
-    assert "XX.AAA.00.BHZ" in text
-    assert "XX.BBB..BHN" in text
-    assert "Consistent: `✔️`" in text or "Consistent: `❌`" in text
+    # Keep only 1
+    report.delete_old_reports(tmp_path, keep=1)
+    remaining = list(tmp_path.glob("*.json"))
+    assert len(remaining) == 1
+    # Only latest seed should remain
+    text = remaining[0].read_text()
+    assert '"seed": 3' in text
+
+
+def test_delete_old_reports_dir_missing(tmp_path):
+    # Non-existing dir → should just return
+    missing = tmp_path / "nope"
+    assert not missing.exists()
+    report.delete_old_reports(missing, keep=1)  # should not raise
+
+def test_delete_old_reports_file_not_found(monkeypatch, tmp_path):
+    recs = make_dummy_records()
+    obj = report.create_report_object("TEST", seed=10, epochs=1, duration=600, records=recs)
+
+    # Save a JSON report
+    json_path = report.save_report_json(obj, output_dir=tmp_path)
+    md_path = json_path.with_suffix(".md")
+    md_path.write_text("dummy-md")
+
+    # Monkeypatch Path.unlink to raise FileNotFoundError only for this json file
+    original_unlink = Path.unlink
+
+    def fake_unlink(p: Path, *a, **kw):
+        if p == json_path:
+            raise FileNotFoundError
+        return original_unlink(p, *a, **kw)
+
+    monkeypatch.setattr(Path, "unlink", fake_unlink)
+
+    # Run cleanup → should trigger the FileNotFoundError branch
+    report.delete_old_reports(tmp_path, keep=0)
+
+    # Markdown should also be gone
+    assert not md_path.exists()

--- a/tests/services/test_availability.py
+++ b/tests/services/test_availability.py
@@ -1,175 +1,218 @@
-import logging
 import pytest
+import logging
+from datetime import datetime
 
-import eida_consistency.services.availability as availability
-
-
-class DummyResponse:
-    def __init__(self, status_code=200, payload=None, text="dummy"):
-        self.status_code = status_code
-        self._payload = payload or {}
-        self.text = text
-
-    def json(self):
-        return self._payload
+import eida_consistency.services.availability as avail
 
 
-def test_collect_spans_with_availability_and_datasources():
+def test_parse_iso_variants():
+    assert avail._parse_iso("2020-01-01T00:00:00") == datetime(2020, 1, 1, 0, 0)
+    assert avail._parse_iso("2020-01-01T00:00:00Z") == datetime(2020, 1, 1, 0, 0)
+
+
+def test_collect_spans_from_availability_and_datasources():
     payload = {
         "availability": [
-            {"start": "2020-01-01T00:00:00", "end": "2020-01-01T01:00:00",
-             "network": "XX", "station": "AAA", "channel": "BHZ", "location": ""}
+            {"network": "XX", "station": "AAA", "channel": "HHZ",
+             "location": "00", "quality": "B",
+             "start": "2020-01-01T00:00:00", "end": "2020-01-01T01:00:00"}
         ],
         "datasources": [
             {
-                "network": "YY", "station": "BBB", "channel": "HHZ", "location": "00",
-                "timespans": [["2020-01-01T02:00:00", "2020-01-01T03:00:00"]]
+                "network": "YY", "station": "BBB", "channel": "EHN", "location": "01", "quality": "M",
+                "timespans": [["2021-01-01T00:00:00", "2021-01-01T02:00:00"]]
             }
         ]
     }
-    spans = availability._collect_spans(payload)
+    spans = avail._collect_spans(payload)
     assert len(spans) == 2
     assert spans[0]["network"] == "XX"
     assert spans[1]["network"] == "YY"
 
 
-def test_check_availability_query_happy_path(monkeypatch):
-    payload = {
-        "availability": [
-            {"start": "2020-01-01T00:00:00", "end": "2020-01-01T01:00:00",
-             "network": "XX", "station": "AAA", "channel": "BHZ", "location": ""}
-        ]
-    }
-    monkeypatch.setattr(
-        availability.requests,
-        "get",
-        lambda url, timeout: DummyResponse(200, payload),
-    )
+class DummyResp:
+    def __init__(self, status_code=200, json_data=None, text=""):
+        self.status_code = status_code
+        self._json = json_data
+        self.text = text
+        self.content = b"{}"
 
-    result = availability.check_availability_query(
-        "http://fake/", "XX", "AAA", "BHZ",
-        "2020-01-01T00:10:00", "2020-01-01T00:20:00"
+    def json(self):
+        if self._json is None:
+            raise ValueError("No JSON")
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception("HTTP error")
+
+
+def test_check_availability_query_success_covering(monkeypatch):
+    def fake_get(url, timeout=20):
+        return DummyResp(
+            200,
+            {"availability": [
+                {"network": "XX", "station": "AAA", "channel": "HHZ", "location": "00",
+                 "start": "2020-01-01T00:00:00", "end": "2020-01-01T02:00:00"}
+            ]}
+        )
+    monkeypatch.setattr(avail.requests, "get", fake_get)
+
+    result = avail.check_availability_query(
+        "http://fake/", "XX", "AAA", "HHZ",
+        "2020-01-01T00:30:00", "2020-01-01T01:00:00", location="00"
     )
     assert result["ok"] is True
     assert result["matched_span"] is not None
+    assert result["status"] == 200
 
 
-def test_non_200_status(monkeypatch, caplog):
-    monkeypatch.setattr(
-        availability.requests,
-        "get",
-        lambda url, timeout: DummyResponse(404, {}, text="not found"),
-    )
+def test_check_availability_query_success_not_covering(monkeypatch):
+    def fake_get(url, timeout=20):
+        return DummyResp(
+            200,
+            {"availability": [
+                {"network": "XX", "station": "AAA", "channel": "HHZ", "location": "00",
+                 "start": "2020-01-01T00:00:00", "end": "2020-01-01T00:10:00"}
+            ]}
+        )
+    monkeypatch.setattr(avail.requests, "get", fake_get)
 
-    caplog.set_level(logging.DEBUG)
-    result = availability.check_availability_query(
-        "http://fake/", "XX", "AAA", "BHZ",
-        "2020-01-01T00:10:00", "2020-01-01T00:20:00"
-    )
-    assert result["ok"] is False
-    assert "Non-200" in caplog.text
-
-
-def test_request_exception(monkeypatch):
-    monkeypatch.setattr(
-        availability.requests,
-        "get",
-        lambda url, timeout: (_ for _ in ()).throw(RuntimeError("boom")),
-    )
-
-    result = availability.check_availability_query(
-        "http://fake/", "XX", "AAA", "BHZ",
-        "2020-01-01T00:10:00", "2020-01-01T00:20:00"
-    )
-    assert result["ok"] is False
-    assert result["status"] == 0
-
-
-def test_bad_json_parse(monkeypatch, caplog):
-    class BadResponse(DummyResponse):
-        def json(self):
-            raise ValueError("bad json")
-
-    monkeypatch.setattr(
-        availability.requests,
-        "get",
-        lambda url, timeout: BadResponse(200),
-    )
-
-    caplog.set_level(logging.WARNING)
-    result = availability.check_availability_query(
-        "http://fake/", "XX", "AAA", "BHZ",
-        "2020-01-01T00:10:00", "2020-01-01T00:20:00"
-    )
-    assert result["ok"] is False
-    assert "Failed to parse" in caplog.text
-
-
-def test_debug_logging_with_unserializable_json(monkeypatch, caplog):
-    # object guaranteed unserialisable
-    bad_obj = lambda: None
-    bad_payload = {
-        "availability": [
-            {"start": "2020-01-01T00:00:00", "end": "2020-01-01T01:00:00", "bad": bad_obj}
-        ]
-    }
-
-    monkeypatch.setattr(
-        availability.requests,
-        "get",
-        lambda url, timeout: DummyResponse(200, bad_payload),
-    )
-
-    caplog.set_level(logging.DEBUG)
-    result = availability.check_availability_query(
-        "http://fake/", "XX", "AAA", "BHZ",
-        "2020-01-01T00:10:00", "2020-01-01T00:20:00"
-    )
-
-    assert "<unserializable JSON>" in caplog.text
-    assert result["ok"] is True   # span still covers window
-
-
-def test_span_with_invalid_datetime_triggers_continue(monkeypatch):
-    bad_payload = {
-        "availability": [{"start": "NOT_A_DATE", "end": "ALSO_BAD"}]
-    }
-
-    monkeypatch.setattr(
-        availability.requests,
-        "get",
-        lambda url, timeout: DummyResponse(200, bad_payload),
-    )
-
-    result = availability.check_availability_query(
-        "http://fake/", "ZZ", "CCC", "HHN",
-        "2020-01-01T00:00:00", "2020-01-01T00:10:00"
+    result = avail.check_availability_query(
+        "http://fake/", "XX", "AAA", "HHZ",
+        "2020-01-01T00:30:00", "2020-01-01T01:00:00", location="00"
     )
     assert result["ok"] is False
     assert result["matched_span"] is None
-    assert len(result["spans"]) == 1
 
 
-def test_check_availability_wrapper(monkeypatch):
-    payload = {
-        "availability": [
-            {"start": "2020-01-01T00:00:00", "end": "2020-01-01T01:00:00"}
-        ]
-    }
-    monkeypatch.setattr(
-        availability.requests,
-        "get",
-        lambda url, timeout: DummyResponse(200, payload),
+def test_check_availability_query_204(monkeypatch):
+    def fake_get(url, timeout=20):
+        return DummyResp(204, json_data={}, text="")
+    monkeypatch.setattr(avail.requests, "get", fake_get)
+
+    result = avail.check_availability_query(
+        "http://fake/", "XX", "AAA", "HHZ", "2020-01-01T00:00:00", "2020-01-01T01:00:00"
+    )
+    assert result["ok"] is False
+    assert result["status"] == 204
+
+
+def test_check_availability_query_non_200(monkeypatch):
+    def fake_get(url, timeout=20):
+        return DummyResp(500, json_data=None, text="err")
+    monkeypatch.setattr(avail.requests, "get", fake_get)
+
+    result = avail.check_availability_query(
+        "http://fake/", "X", "A", "HHZ", "s", "e"
+    )
+    assert result["ok"] is False
+    assert result["status"] == 0   # code catches error and forces 0
+
+
+def test_check_availability_query_invalid_json(monkeypatch):
+    def fake_get(url, timeout=20):
+        return DummyResp(200, json_data=None)
+    monkeypatch.setattr(avail.requests, "get", fake_get)
+
+    result = avail.check_availability_query(
+        "http://fake/", "X", "A", "HHZ", "2020-01-01T00:00:00", "2020-01-01T00:10:00"
+    )
+    assert result["ok"] is False
+    assert result["spans"] == []
+
+
+def test_get_availability_spans_success(monkeypatch):
+    def fake_get(url, timeout=30):
+        return DummyResp(
+            200,
+            {"availability": [
+                {"network": "X", "station": "A", "channel": "HHZ",
+                 "start": "2020-01-01T00:00:00", "end": "2020-01-01T01:00:00"}
+            ]}
+        )
+    monkeypatch.setattr(avail.requests, "get", fake_get)
+    spans = avail.get_availability_spans("http://fake/", "X", "A", "HHZ", "s", "e")
+    assert len(spans) == 1
+
+
+def test_get_availability_spans_204_retry_then_empty(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_get(url, timeout=30):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return DummyResp(204, json_data={})
+        return DummyResp(204, json_data={})
+    monkeypatch.setattr(avail.requests, "get", fake_get)
+
+    spans = avail.get_availability_spans("http://fake/", "X", "A", "HHZ", "s", "e", location="00")
+    assert spans == []
+
+
+def test_get_availability_spans_exception(monkeypatch):
+    def fake_get(url, timeout=30):
+        raise Exception("boom")
+    monkeypatch.setattr(avail.requests, "get", fake_get)
+
+    spans = avail.get_availability_spans("http://fake/", "X", "A", "HHZ", "s", "e")
+    assert spans == []
+
+
+def test_check_availability_backcompat(monkeypatch):
+    def fake_query(*a, **k):
+        return {"ok": True, "url": "http://fake", "spans": [], "matched_span": {}}
+    monkeypatch.setattr(avail, "check_availability_query", fake_query)
+
+    res = avail.check_availability("http://fake/", "X", "A", "HHZ", "s", "e")
+    assert res is True
+
+    url, ok = avail.check_availability("http://fake/", "X", "A", "HHZ", "s", "e", return_url=True)
+    assert url == "http://fake"
+    assert ok is True
+
+
+# --- NEW TESTS FOR UNCOVERED BRANCHES ---
+
+def test_check_availability_query_unserializable_json(monkeypatch, caplog):
+    """Force unserializable JSON payload so pretty-print fails but code continues."""
+    class BadObj:
+        # Not JSON serializable
+        pass
+
+    bad_payload = {"availability": [{"network": "X", "station": "A", "channel": "HHZ",
+                                     "location": "00", "start": "2020-01-01T00:00:00",
+                                     "end": "2020-01-01T00:10:00",
+                                     "extra": BadObj()}]}
+
+    def fake_get(url, timeout=20):
+        return DummyResp(200, json_data=bad_payload)
+
+    monkeypatch.setattr(avail.requests, "get", fake_get)
+    caplog.set_level(logging.DEBUG)
+
+    result = avail.check_availability_query(
+        "http://fake/", "X", "A", "HHZ",
+        "2020-01-01T00:00:00", "2020-01-01T00:10:00"
     )
 
-    result = availability.check_availability(
-        "http://fake/", "XX", "AAA", "BHZ",
-        "2020-01-01T00:10:00", "2020-01-01T00:20:00"
+    assert isinstance(result, dict)
+    # The pretty string should fall back to "<unserializable JSON>"
+    assert "<unserializable JSON>" in caplog.text
+
+def test_check_availability_query_span_parse_exception(monkeypatch):
+    """Force _parse_iso to fail so except Exception: continue is exercised."""
+    payload = {"availability": [{"start": "bad-date", "end": "also-bad"}]}
+
+    def fake_get(url, timeout=20):
+        return DummyResp(200, json_data=payload)
+
+    monkeypatch.setattr(avail.requests, "get", fake_get)
+
+    result = avail.check_availability_query(
+        "http://fake/", "X", "A", "HHZ",
+        "2020-01-01T00:00:00", "2020-01-01T00:10:00"
     )
-    assert isinstance(result, bool)
-    url, ok = availability.check_availability(
-        "http://fake/", "XX", "AAA", "BHZ",
-        "2020-01-01T00:10:00", "2020-01-01T00:20:00", return_url=True
-    )
-    assert url.startswith("http://fake/")
-    assert isinstance(ok, bool)
+
+    assert result["ok"] is False
+    assert result["matched_span"] is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,231 +1,136 @@
 import json
-import logging
 import runpy
 import sys
-from click.testing import CliRunner
-from unittest.mock import patch
 import pytest
 import click
+from pathlib import Path
+from click.testing import CliRunner
 
-from eida_consistency.cli import cli
-
-
-# ---------- Helpers ------------------------------------------------------------
-
-def assert_called_with_subset(mock, **expected_subset):
-    """Assert last call's kwargs contain at least this subset."""
-    assert mock.call_args is not None, "Function was not called"
-    actual = mock.call_args.kwargs
-    for k, v in expected_subset.items():
-        assert actual.get(k) == v, f"Expected {k}={v}, got {actual.get(k)}"
+import eida_consistency.cli as cli
 
 
-def _find_log_level_normalizer():
-    """
-    Try common helper names used for log-level normalization.
-    """
-    import eida_consistency.cli as cli_mod
-
-    candidates = [
-        "_normalize_log_level",
-        "normalize_log_level",
-        "_coerce_log_level",
-        "coerce_log_level",
-        "_parse_log_level",
-        "parse_log_level",
-    ]
-    for name in candidates:
-        fn = getattr(cli_mod, name, None)
-        if callable(fn):
-            return fn
-    return None
+# -------------------------------------------------------------------
+# Helpers
+# -------------------------------------------------------------------
+def make_dummy_report(tmp_path: Path, name="r.json"):
+    """Create a minimal dummy report JSON file."""
+    path = tmp_path / name
+    report = {"summary": {}, "results": []}
+    path.write_text(json.dumps(report))
+    return path
 
 
-# ---------- CLI: consistency ---------------------------------------------------
-
-@patch("eida_consistency.cli.run_consistency_check")
-def test_consistency_prints_json_and_calls_runner(mock_run):
-    # Simulate runner printing JSON to stdout; CLI should surface it
-    mock_run.side_effect = lambda **kwargs: print(
-        json.dumps({"summary": {"node": kwargs["node"], "epochs": kwargs["epochs"]}})
-    )
-
+# -------------------------------------------------------------------
+# consistency command
+# -------------------------------------------------------------------
+def test_consistency_with_node_and_delete_old(monkeypatch, tmp_path, caplog):
     runner = CliRunner()
-    result = runner.invoke(
-        cli,
-        [
-            "--log-level", "DEBUG",
-            "consistency",
-            "--node", "NOA",
-            "--epochs", "2",
-            "--duration", "600",
-            "--seed", "123",
-        ],
-    )
+    caplog.set_level("INFO")
 
+    # Patch housekeeping
+    monkeypatch.setattr(cli, "delete_old_reports", lambda *_a, **_k: caplog.messages.append("delete called"))
+
+    result = runner.invoke(cli.cli, ["consistency", "--delete-old"])
     assert result.exit_code == 0
-    out = json.loads(result.output.strip())
-    assert out["summary"]["node"] == "NOA"
-    assert out["summary"]["epochs"] == 2
-
-    assert_called_with_subset(
-        mock_run,
-        node="NOA",
-        epochs=2,
-        duration=600,
-        seed=123,
-    )
+    assert any("delete called" in msg or "Old reports cleaned" in msg for msg in caplog.messages)
 
 
-@patch("eida_consistency.cli.run_consistency_check")
-def test_consistency_accepts_log_level_option_and_forwards_core_args(mock_run):
-    mock_run.side_effect = lambda **kwargs: None
-
+def test_consistency_with_node_and_seed(monkeypatch):
     runner = CliRunner()
-    result = runner.invoke(
-        cli,
-        ["--log-level", "INFO", "consistency", "--node", "RESIF", "--epochs", "1"],
-    )
+    called = {}
 
+    monkeypatch.setattr(cli, "run_consistency_check", lambda **kwargs: called.update(kwargs))
+
+    result = runner.invoke(cli.cli, ["consistency", "--node", "FAKE", "--epochs", "2", "--seed", "123"])
     assert result.exit_code == 0
-    assert_called_with_subset(
-        mock_run,
-        node="RESIF",
-        epochs=1,
-        duration=600,  # default
-        seed=None,
-    )
+    assert called["node"] == "FAKE"
+    assert called["epochs"] == 2
+    assert called["seed"] == 123
 
 
-def test_consistency_requires_node_option():
+def test_consistency_fails_without_node():
     runner = CliRunner()
-    result = runner.invoke(cli, ["consistency", "--epochs", "1"])
+    result = runner.invoke(cli.cli, ["consistency"])
     assert result.exit_code != 0
-    assert "Error" in result.output
+    assert "--node is required" in result.output
 
 
-def test_consistency_requires_epochs_int():
+def test_consistency_invalid_duration():
     runner = CliRunner()
-    result = runner.invoke(cli, ["consistency", "--node", "NOA", "--epochs", "not-an-int"])
+    result = runner.invoke(cli.cli, ["consistency", "--node", "FAKE", "--duration", "100"])
     assert result.exit_code != 0
-    assert "Invalid value" in result.output or "Error" in result.output
+    assert "Duration must be at least" in result.output
 
 
-@patch("eida_consistency.cli.delete_old_reports")
-def test_consistency_delete_old_cleans_reports(mock_cleanup):
+# -------------------------------------------------------------------
+# compare command
+# -------------------------------------------------------------------
+def test_compare_command(monkeypatch, tmp_path):
     runner = CliRunner()
-    result = runner.invoke(cli, ["consistency", "--delete-old"])
+    dummy1 = make_dummy_report(tmp_path, "r1.json")
+    dummy2 = make_dummy_report(tmp_path, "r2.json")
+
+    called = {}
+    monkeypatch.setattr(cli, "compare_reports", lambda a, b: called.update({"a": a, "b": b}))
+
+    result = runner.invoke(cli.cli, ["compare", str(dummy1), str(dummy2)])
     assert result.exit_code == 0
-    mock_cleanup.assert_called_once()
+    assert called["a"].endswith("r1.json")
+    assert called["b"].endswith("r2.json")
 
 
-@patch("eida_consistency.cli.run_consistency_check")
-def test_consistency_explicit_duration_forwarded(mock_run):
-    mock_run.side_effect = lambda **kwargs: None
-
+# -------------------------------------------------------------------
+# explore command
+# -------------------------------------------------------------------
+def test_explore_with_explicit_report_and_index(monkeypatch, tmp_path):
     runner = CliRunner()
-    result = runner.invoke(
-        cli,
-        ["consistency", "--node", "ETH", "--epochs", "3", "--duration", "900"],
-    )
+    dummy_report = make_dummy_report(tmp_path)
+
+    called = {}
+    monkeypatch.setattr(cli, "explore_boundaries", lambda report, indices: called.update({"report": str(report), "indices": indices}))
+
+    result = runner.invoke(cli.cli, ["explore", str(dummy_report), "--index", "1,2"])
     assert result.exit_code == 0
-    assert_called_with_subset(
-        mock_run,
-        node="ETH",
-        epochs=3,
-        duration=900,
-        seed=None,
-    )
+    assert called["report"].endswith("r.json")
+    assert called["indices"] == [1, 2]
 
 
-def test_consistency_rejects_duration_too_small():
+def test_explore_with_no_report_uses_latest(monkeypatch, tmp_path):
     runner = CliRunner()
-    result = runner.invoke(
-        cli,
-        ["consistency", "--node", "ETH", "--epochs", "1", "--duration", "300"],
-    )
-    assert result.exit_code != 0
-    assert "Duration must be at least 600" in result.output
+    dummy_report = make_dummy_report(tmp_path, "latest.json")
+    cli.REPORT_DIR = tmp_path  # point to tmp_path
 
+    called = {}
+    monkeypatch.setattr(cli, "explore_boundaries", lambda report, indices: called.update({"report": str(report), "indices": indices}))
 
-@patch("eida_consistency.cli.run_consistency_check")
-def test_consistency_runner_exception_propagates_nonzero(mock_run):
-    mock_run.side_effect = RuntimeError("boom")
-
-    runner = CliRunner()
-    result = runner.invoke(cli, ["consistency", "--node", "NOA", "--epochs", "1"])
-    assert result.exit_code != 0
-    if result.exception is not None:
-        assert isinstance(result.exception, RuntimeError)
-
-
-# ---------- CLI: compare -------------------------------------------------------
-
-@patch("eida_consistency.cli.compare_reports")
-def test_cli_compare_calls_compare_reports(mock_compare, tmp_path):
-    f1 = tmp_path / "report1.json"
-    f2 = tmp_path / "report2.json"
-    f1.write_text("{}")
-    f2.write_text("{}")
-
-    runner = CliRunner()
-    result = runner.invoke(cli, ["compare", str(f1), str(f2)])
-
+    result = runner.invoke(cli.cli, ["explore"])
     assert result.exit_code == 0
-    mock_compare.assert_called_once_with(str(f1), str(f2))
+    assert Path(called["report"]).name == "latest.json"
+    assert called["indices"] is None
 
 
-@patch("eida_consistency.cli.compare_reports")
-def test_compare_requires_two_paths(mock_compare):
+def test_explore_no_reports_found(monkeypatch, tmp_path):
     runner = CliRunner()
-    result = runner.invoke(cli, ["compare", "only_one.json"])
+    cli.REPORT_DIR = tmp_path  # empty dir
+    result = runner.invoke(cli.cli, ["explore"])
     assert result.exit_code != 0
-    assert "Missing argument" in result.output or "Error" in result.output
-    mock_compare.assert_not_called()
+    assert "No report files found" in result.output
 
 
-@patch("eida_consistency.cli.compare_reports")
-def test_compare_exception_is_nonzero(mock_compare, tmp_path):
-    f1 = tmp_path / "report1.json"
-    f2 = tmp_path / "report2.json"
-    f1.write_text("{}")
-    f2.write_text("{}")
+# -------------------------------------------------------------------
+# Extra coverage: uncovered lines in cli.py
+# -------------------------------------------------------------------
+def test_invalid_log_level_raises():
+    with pytest.raises(click.BadParameter):
+        cli.normalize_log_level("INVALID")
 
-    mock_compare.side_effect = ValueError("cannot compare")
 
+def test_cli_no_subcommand_shows_help_and_exits():
     runner = CliRunner()
-    result = runner.invoke(cli, ["compare", str(f1), str(f2)])
-    assert result.exit_code != 0
+    result = runner.invoke(cli.cli, [])
+    assert result.exit_code == 1
+    assert "EIDA consistency checker" in result.output
 
-
-# ---------- CLI: top-level -----------------------------------------------------
-
-def test_cli_no_subcommand_shows_usage_and_exits_nonzero():
-    runner = CliRunner()
-    result = runner.invoke(cli, [])
-    assert result.exit_code != 0
-    assert "Usage:" in result.output
-
-
-# ---------- Direct coverage of log-level normalizer ---------------------------
-
-def test_log_level_normalizer_invalid_raises_badparameter():
-    normalizer = _find_log_level_normalizer()
-    assert normalizer is not None
-    with pytest.raises(click.BadParameter) as excinfo:
-        normalizer("BANANA")
-    assert "Invalid log level" in str(excinfo.value)
-
-
-def test_log_level_normalizer_valid_returns_int():
-    normalizer = _find_log_level_normalizer()
-    assert normalizer is not None
-    val = normalizer("INFO")
-    assert isinstance(val, int)
-    assert val == logging.INFO
-
-
-# ---------- __main__ guard coverage -------------------------------------------
 
 def test_module_runs_via___main__(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["eida_consistency.cli", "--help"])

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -1,0 +1,164 @@
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+import eida_consistency.explorer as explorer
+
+
+class DummyDS:
+    """Dummy dataselect responses."""
+    ok = {"success": True, "status": "OK"}
+    fail = {"success": False, "status": "NoData"}
+
+
+class DummyAvail:
+    """Dummy availability spans."""
+
+    @staticmethod
+    def covered(*args, **kwargs):
+        return [{"start": "2020-01-01T00:00:00", "end": "2100-01-01T00:00:00"}]
+
+    @staticmethod
+    def empty(*args, **kwargs):
+        return []
+
+
+def make_report(tmp_path: Path, results):
+    report = {
+        "summary": {"node": "RESIF", "seed": 123, "epochs": 1,
+                    "duration": 600, "total_checked": len(results),
+                    "total_consistent": 0, "total_inconsistent": 0,
+                    "timestamp": "2025-01-01T00:00:00"},
+        "results": results,
+    }
+    p = tmp_path / "report.json"
+    p.write_text(json.dumps(report))
+    return p
+
+
+def test_parse_iso_variants():
+    # With Z suffix
+    dt = explorer._parse_iso("2020-01-01T00:00:00Z")
+    assert dt.tzinfo == timezone.utc
+    # Naive string
+    dt2 = explorer._parse_iso("2020-01-01T00:00:00")
+    assert dt2.tzinfo == timezone.utc
+    # None
+    assert explorer._parse_iso(None) is None
+
+
+def test_iso_format_roundtrip():
+    now = datetime.now(timezone.utc)
+    s = explorer._iso(now)
+    assert "T" in s and s.endswith(":00") is False
+
+
+def test_slice_consistent_true(monkeypatch):
+    monkeypatch.setattr(explorer, "get_availability_spans", DummyAvail.covered)
+    monkeypatch.setattr(explorer, "dataselect", lambda *a, **k: DummyDS.ok)
+    t0 = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    t1 = t0 + timedelta(minutes=10)
+    res = explorer._slice_consistent("url", "XX", "STA", "BHZ", "00", t0, t1)
+    assert res is True
+
+
+def test_slice_consistent_false(monkeypatch):
+    # availability covered but dataselect fails
+    monkeypatch.setattr(explorer, "get_availability_spans", DummyAvail.covered)
+    monkeypatch.setattr(explorer, "dataselect", lambda *a, **k: DummyDS.fail)
+    t0 = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    t1 = t0 + timedelta(minutes=10)
+    res = explorer._slice_consistent("url", "XX", "STA", "BHZ", "00", t0, t1)
+    assert res is False
+
+
+def test_explore_boundaries_no_targets(tmp_path, caplog):
+    report = make_report(tmp_path, results=[{"index": 1, "consistent": True}])
+    caplog.set_level(logging.INFO)
+    explorer.explore_boundaries(report)
+    assert "No targets" in caplog.text
+
+
+def test_explore_boundaries_with_indices(monkeypatch, tmp_path, caplog):
+    # One inconsistent record
+    results = [{
+        "index": 7, "network": "XX", "station": "STA", "channel": "BHZ", "location": "00",
+        "starttime": "2020-01-01T00:00:00", "endtime": "2020-01-01T00:10:00",
+        "available": True, "dataselect_success": False, "consistent": False
+    }]
+    report = make_report(tmp_path, results)
+
+    # Mocks: availability empty, dataselect fail always
+    monkeypatch.setattr(explorer, "get_availability_spans", DummyAvail.empty)
+    monkeypatch.setattr(explorer, "dataselect", lambda *a, **k: DummyDS.fail)
+    monkeypatch.setattr(explorer, "load_node_url", lambda n: "http://fake/")
+
+    caplog.set_level(logging.INFO)
+    explorer.explore_boundaries(report, indices=[7], max_days=1)
+
+    # Should log exploration and suggest clean
+    assert "Exploring inconsistency" in caplog.text
+    assert "Suggested command:" in caplog.text
+    assert "dmtri clean" in caplog.text
+
+
+def test_explore_boundaries_forward_backward_limits(monkeypatch, tmp_path, caplog):
+    results = [{
+        "index": 1, "network": "XX", "station": "STA", "channel": "BHZ", "location": "00",
+        "starttime": "2020-01-01T00:00:00", "endtime": "2020-01-01T00:10:00",
+        "available": False, "dataselect_success": True, "consistent": False
+    }]
+    report = make_report(tmp_path, results)
+
+    # Force always inconsistent (covered vs ds mismatch)
+    monkeypatch.setattr(explorer, "get_availability_spans", DummyAvail.covered)
+    monkeypatch.setattr(explorer, "dataselect", lambda *a, **k: DummyDS.fail)
+    monkeypatch.setattr(explorer, "load_node_url", lambda n: "http://fake/")
+
+    caplog.set_level(logging.INFO)
+    explorer.explore_boundaries(report, max_days=1)
+
+    # Should warn about reaching limits
+    assert "⚠️ Reached max" in caplog.text
+    assert "dmtri refresh" in caplog.text
+def test_explore_boundaries_backward_limit_else(monkeypatch, tmp_path, caplog):
+    """Covers the 'else:' block of the backward search loop."""
+    results = [{
+        "index": 42, "network": "XX", "station": "STA", "channel": "BHZ", "location": "00",
+        "starttime": "2020-01-01T00:00:00", "endtime": "2020-01-01T00:10:00",
+        "available": True, "dataselect_success": False, "consistent": False
+    }]
+    report = make_report(tmp_path, results)
+
+    # Always inconsistent → never breaks the loop
+    monkeypatch.setattr(explorer, "get_availability_spans", DummyAvail.covered)
+    monkeypatch.setattr(explorer, "dataselect", lambda *a, **k: DummyDS.fail)
+    monkeypatch.setattr(explorer, "load_node_url", lambda n: "http://fake/")
+
+    caplog.set_level(logging.INFO)
+    explorer.explore_boundaries(report, max_days=0)  # forces the `else` branch
+
+    assert "⚠️ Reached max backward search limit" in caplog.text
+
+
+def test_explore_boundaries_cmd_refresh_fallback(monkeypatch, tmp_path, caplog):
+    """Covers the fallback cmd = 'refresh' branch when available == ds_success."""
+    results = [{
+        "index": 99, "network": "XX", "station": "STA", "channel": "BHZ", "location": "00",
+        "starttime": "2020-01-01T00:00:00", "endtime": "2020-01-01T00:10:00",
+        "available": True, "dataselect_success": True, "consistent": True
+    }]
+    report = make_report(tmp_path, results)
+
+    # These values won’t be used since the record is already consistent
+    monkeypatch.setattr(explorer, "get_availability_spans", DummyAvail.empty)
+    monkeypatch.setattr(explorer, "dataselect", lambda *a, **k: DummyDS.ok)
+    monkeypatch.setattr(explorer, "load_node_url", lambda n: "http://fake/")
+
+    caplog.set_level(logging.INFO)
+    explorer.explore_boundaries(report, indices=[99], max_days=1)
+
+    assert "dmtri refresh" in caplog.text

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,122 +1,107 @@
-import pytest
-import logging
-from unittest.mock import patch
-from eida_consistency import runner
 import json
-
-@pytest.fixture(autouse=True)
-def patch_dependencies(tmp_path):
-    """Patch external dependencies of runner so tests stay isolated."""
-    with patch("eida_consistency.runner.fetch_candidates") as mock_fetch, \
-         patch("eida_consistency.runner.dataselect") as mock_ds, \
-         patch("eida_consistency.runner.check_candidate") as mock_check, \
-         patch("eida_consistency.runner.load_node_url") as mock_url, \
-         patch("eida_consistency.runner.format_result") as mock_fmt, \
-         patch("eida_consistency.runner.create_report_object") as mock_create, \
-         patch("eida_consistency.runner.save_report_json") as mock_save_json, \
-         patch("eida_consistency.runner.save_report_markdown") as mock_save_md:
-
-        # defaults
-        mock_url.return_value = "http://example/fdsnws"
-        mock_fetch.return_value = [
-            {"network": "XX", "station": "AAA", "channel": "BHZ", "location": ""}
-        ]
-        mock_check.return_value = [
-            ("http://example?network=XX&station=AAA&channel=BHZ", True, "2020-01-01", "2020-01-02", "")
-        ]
-        mock_ds.return_value = {"success": True, "status": "200", "type": "mseed"}
-        mock_fmt.side_effect = lambda *a, **k: "formatted-log"
-        mock_create.side_effect = lambda **kw: {
-            "summary": {"node": kw["node"], "seed": kw["seed"]},
-            "results": kw["records"],
-        }
-        mock_save_json.return_value = tmp_path / "report.json"
-        mock_save_md.return_value = tmp_path / "report.md"
-
-        yield {
-            "fetch": mock_fetch,
-            "dataselect": mock_ds,
-            "check": mock_check,
-            "url": mock_url,
-            "fmt": mock_fmt,
-            "create": mock_create,
-            "save_json": mock_save_json,
-            "save_md": mock_save_md,
-        }
+import pytest
+import eida_consistency.runner as runner
 
 
-def test_run_consistency_check_normal(patch_dependencies, caplog):
-    caplog.set_level(logging.INFO)
+def test_generated_seed_branch(monkeypatch, caplog):
+    """Covers: seed = random.randint... and logging.info generated seed."""
+    caplog.set_level("INFO")
 
-    runner.run_consistency_check("NOA", epochs=1, duration=60, seed=123, max_workers=2)
+    # Force fetch_candidates to return [] so it exits quickly
+    monkeypatch.setattr(runner, "fetch_candidates", lambda base_url: [])
+    monkeypatch.setattr(runner, "load_node_url", lambda node: "http://fake/")
 
-    patch_dependencies["fetch"].assert_called_once()
-    patch_dependencies["check"].assert_called_once()
-    assert patch_dependencies["dataselect"].called
-    assert patch_dependencies["save_json"].called
-    assert patch_dependencies["save_md"].called
-    assert any("Collected" in rec.message for rec in caplog.records)
-
-
-def test_run_consistency_check_no_candidates(patch_dependencies, caplog):
-    patch_dependencies["fetch"].return_value = []
-    caplog.set_level(logging.WARNING)
-
-    result = runner.run_consistency_check("NOA", seed=1)
-    assert result is None
-    assert any("No candidates" in rec.message for rec in caplog.records)
+    runner.run_consistency_check(node="FAKE")
+    assert "Using generated seed" in caplog.text
 
 
-def test_run_consistency_check_uses_generated_seed(patch_dependencies, caplog):
-    caplog.set_level(logging.INFO)
-    runner.run_consistency_check("NOA")  # no seed passed
-    assert any("Using generated seed" in rec.message for rec in caplog.records)
+def test_no_candidates_branch(monkeypatch, caplog):
+    """Covers: logging.warning('No candidates fetched.') and return."""
+    caplog.set_level("INFO")
+
+    monkeypatch.setattr(runner, "fetch_candidates", lambda base_url: [])
+    monkeypatch.setattr(runner, "load_node_url", lambda node: "http://fake/")
+
+    runner.run_consistency_check(node="FAKE", seed=123)
+    assert "No candidates fetched." in caplog.text
 
 
-def test_worker_builds_inconsistent_record(patch_dependencies):
-    """Force available != dataselect.success → inconsistent=False case covered."""
-    # mismatch here: available=True but dataselect.success=False
-    patch_dependencies["check"].return_value = [
-        ("http://example?network=XX&station=AAA&channel=BHZ", True, "2020-01-01", "2020-01-02", "")
-    ]
-    patch_dependencies["dataselect"].return_value = {
-        "success": False,
-        "status": "500",
-        "type": "mseed",
-        "debug": "fail",
+def test_parse_failure_branch(monkeypatch, tmp_path):
+    """Covers: except Exception -> net,sta,cha = '?','?','?'"""
+    fake_candidate = {
+        "network": "X",
+        "station": "Y",
+        "channel": "Z",
+        "starttime": "2020-01-01T00:00:00",
     }
 
-    runner.run_consistency_check("NOA", epochs=1, seed=42)
+    monkeypatch.setattr(runner, "fetch_candidates", lambda base_url: [fake_candidate])
+    monkeypatch.setattr(runner, "load_node_url", lambda node: "http://fake/")
 
-    records = patch_dependencies["create"].call_args[1]["records"]
-    assert records[0]["consistent"] is False
-    assert records[0]["dataselect_status"] == "500"
+    # Provide URL with no query string -> triggers parse failure
+    monkeypatch.setattr(
+        runner,
+        "check_candidate",
+        lambda *a, **k: [("http://fake/noquery", True, "2020-01-01T00:00:00",
+                          "2020-01-01T00:10:00", "00", None)],
+    )
+
+    monkeypatch.setattr(
+        runner,
+        "dataselect",
+        lambda *a, **k: {"success": True, "status": "OK", "type": "SingleTrace", "debug": "dbg"},
+    )
+    monkeypatch.setattr(runner, "format_result", lambda *a, **k: "formatted")
+
+    monkeypatch.setattr(runner, "save_report_json", lambda r, **k: tmp_path / "r.json")
+    monkeypatch.setattr(runner, "save_report_markdown", lambda r, **k: tmp_path / "r.md")
+
+    # Should run without raising and hit parse-failure branch
+    runner.run_consistency_check(node="FAKE", seed=123)
 
 
-def test_url_parse_fallback_to_question_marks(patch_dependencies):
-    """Covers the except branch when URL has no query string."""
-    patch_dependencies["check"].return_value = [
-        ("http://example_without_query", True, "2020-01-01", "2020-01-02", "")
-    ]
-    # Make candidate that matches the fallback "?" values
-    patch_dependencies["fetch"].return_value = [
-        {"network": "?", "station": "?", "channel": "?", "location": ""}
-    ]
+def test_print_stdout_branch(monkeypatch, tmp_path, capsys):
+    """Covers: sys.stdout.write(...) and flush() when print_stdout=True."""
+    fake_candidate = {
+        "network": "X",
+        "station": "Y",
+        "channel": "Z",
+        "starttime": "2020-01-01T00:00:00",
+        "endtime": "2020-01-01T00:10:00",
+    }
 
-    runner.run_consistency_check("NOA", epochs=1, seed=77)
+    monkeypatch.setattr(runner, "fetch_candidates", lambda base_url: [fake_candidate])
+    monkeypatch.setattr(runner, "load_node_url", lambda node: "http://fake/")
 
-    records = patch_dependencies["create"].call_args[1]["records"]
-    assert records[0]["network"] == "?"
-    assert records[0]["station"] == "?"
-    assert records[0]["channel"] == "?"
+    monkeypatch.setattr(
+        runner,
+        "check_candidate",
+        lambda *a, **k: [("http://fake/availability?network=X&station=Y&channel=Z",
+                          True, "2020-01-01T00:00:00", "2020-01-01T00:10:00", "00", None)],
+    )
 
-def test_run_consistency_check_prints_stdout(patch_dependencies, capsys):
-    """Ensure JSON report is written to stdout when print_stdout=True."""
-    runner.run_consistency_check("NOA", epochs=1, seed=123, print_stdout=True)
+    monkeypatch.setattr(
+        runner,
+        "dataselect",
+        lambda *a, **k: {"success": True, "status": "OK", "type": "SingleTrace", "debug": "dbg"},
+    )
+    monkeypatch.setattr(runner, "format_result", lambda *a, **k: "formatted")
 
-    captured = capsys.readouterr().out
-    assert captured.strip()  # not empty
-    data = json.loads(captured)
-    assert "summary" in data
-    assert data["summary"]["node"] == "NOA"
-    assert data["summary"]["seed"] == 123
+    # Save reports to tmp_path
+    def fake_save_json(r, **k):
+        p = tmp_path / "r.json"
+        p.write_text(json.dumps(r))
+        return p
+
+    def fake_save_md(r, **k):
+        p = tmp_path / "r.md"
+        p.write_text("# md")
+        return p
+
+    monkeypatch.setattr(runner, "save_report_json", fake_save_json)
+    monkeypatch.setattr(runner, "save_report_markdown", fake_save_md)
+
+    runner.run_consistency_check(node="FAKE", seed=123, print_stdout=True)
+
+    out = capsys.readouterr().out
+    assert "summary" in out


### PR DESCRIPTION
# Add explorer command, larger availability spans, global score, and tests

## Description
- Added `explore` command to search backward/forward day by day and identify true inconsistency windows (#8).
- Changed availability queries to cover the full channel epoch span, then select random test slices inside it (#7).
- Introduced a global score in report summary, representing percentage of consistent results (#6).
- Expanded test suite.

## Related Issues
Closes #6
Closes #7
Closes #8