### PR TITLE
fix: implement retry logic and error handling 

### DIFF
--- a/src/eida_consistency/cli.py
+++ b/src/eida_consistency/cli.py
@@ -22,6 +22,7 @@ from eida_consistency.runner import run_consistency_check
 from eida_consistency.report.compare import compare_reports
 from eida_consistency.report.report import delete_old_reports, REPORT_DIR
 from eida_consistency.explorer import explore_boundaries
+from eida_consistency.core.consistency import classify_consistency
 from eida_consistency.utils import nodes
 
 
@@ -172,17 +173,18 @@ def check(ctx, node, net, sta, cha, loc, start, end):
     logging.info(f"Checking Dataselect for {net}.{sta}.{loc}.{cha}...")
     ds_res = dataselect(base_url, net, sta, cha, start, end, loc)
     ds_success = ds_res["success"]
-    
-    consistent = (available == ds_success)
+    classification = classify_consistency(available, ds_res)
     
     logging.info(f"\nResults for {net}.{sta}.{loc}.{cha} ({start} -> {end}):")
     logging.info(f"  Availability: {'YES' if available else 'NO'} (status {av_res['status']})")
     logging.info(f"  Dataselect:   {'YES' if ds_success else 'NO'} (status {ds_res['status']})")
-    
-    if consistent:
+
+    if classification["consistent"] is True:
         logging.info("  Summary: CONSISTENT")
-    else:
+    elif classification["consistent"] is False:
         logging.info("  Summary: INCONSISTENT")
+    else:
+        logging.info(f"  Summary: SKIPPED ({classification['reason']})")
         
     if not ds_success and ds_res.get("debug"):
         logging.debug(f"  Debug: {ds_res['debug']}")

--- a/src/eida_consistency/core/consistency.py
+++ b/src/eida_consistency/core/consistency.py
@@ -1,0 +1,52 @@
+"""Consistency classification helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def is_transient_dataselect_failure(success: bool, status: str | None) -> bool:
+    """Return True for transient transport-style Dataselect failures."""
+    if success:
+        return False
+    normalized = str(status or "").strip().lower()
+    if not normalized:
+        return False
+
+    # Keywords for network issues or server-side transient errors
+    transient_keywords = [
+        "timeout",
+        "connection",
+        "http 5",        # HTTP 500, 502, 503, 504
+        "http error 5",
+        "proxy",
+        "ssl",
+        "remote end closed",
+        "broken pipe",
+        "gateway",
+        "unavailable",
+        "internal server error",
+    ]
+    return any(kw in normalized for kw in transient_keywords)
+
+
+def classify_consistency(available: bool, ds_result: Dict[str, Any]) -> Dict[str, Any]:
+    """Classify an availability/dataselect comparison."""
+    ds_success = bool(ds_result["success"])
+    ds_status = ds_result.get("status")
+
+    if is_transient_dataselect_failure(ds_success, ds_status):
+        return {
+            "consistent": None,
+            "scoreable": False,
+            "status": "Skipped",
+            "reason": "TransientDataselectFailure",
+        }
+
+    consistent = available == ds_success
+    return {
+        "consistent": consistent,
+        "scoreable": True,
+        "status": "Consistent" if consistent else "Inconsistent",
+        "reason": None,
+    }

--- a/src/eida_consistency/core/formatter.py
+++ b/src/eida_consistency/core/formatter.py
@@ -1,17 +1,16 @@
-"""Formatter module for logging consistency-check results."""     
+"""Formatter module for logging consistency-check results."""
+
+from __future__ import annotations
+
+from eida_consistency.core.consistency import classify_consistency
+
 
 def format_result(idx, url, available, ds_result, match):
-    net = match["network"]
-    sta = match["station"]
-    cha = match["channel"]
-    loc = match.get("location", "")
-
     original_start = match.get("starttime", "?")
     original_end = match.get("endtime", "?")
 
     log = [f"{idx}. {url}"]
 
-        # Availability result
     if available:
         line = "     Availability: ✅ (timespan covered)"
         matched_span = match.get("matched_span")
@@ -21,13 +20,17 @@ def format_result(idx, url, available, ds_result, match):
     else:
         log.append("     Availability: ❌ (No availability in this timespan)")
 
-
-    # Dataselect result
     dataselect_status = "✅" if ds_result["success"] else f"❌ ({ds_result['status']})"
     log.append(f"     Dataselect:   {dataselect_status}")
 
-    consistent = available == ds_result["success"]
-    log.append(f"     Consistent:   {'✅' if consistent else '❌'}")
+    classification = classify_consistency(available, ds_result)
+    if classification["consistent"] is True:
+        consistency_status = "✅"
+    elif classification["consistent"] is False:
+        consistency_status = "❌"
+    else:
+        consistency_status = f"⚪ ({classification['status']}: {ds_result['status']})"
+    log.append(f"     Consistent:   {consistency_status}")
     log.append(f"     Epoch span: {original_start} → {original_end}")
 
     debug = ds_result.get("debug", "").strip()

--- a/src/eida_consistency/create_md.py
+++ b/src/eida_consistency/create_md.py
@@ -33,8 +33,8 @@ def build_markdown(reports: List[Tuple[Path, Dict[str, Any]]]) -> str:
     # --- Global table ---
     lines.append("## Per-node summary")
     lines.append("")
-    lines.append("| Node | Epochs Requested | Epochs Usable | Total Checks | Consistent | Inconsistent | Score |")
-    lines.append("|------|------------------|---------------|--------------|------------|--------------|-------|")
+    lines.append("| Node | Epochs Requested | Epochs Usable | Total Checks | Skipped | Consistent | Inconsistent | Score |")
+    lines.append("|------|------------------|---------------|--------------|---------|------------|--------------|-------|")
 
     for path, rep in reports:
         s = rep.get("summary", {})
@@ -42,13 +42,14 @@ def build_markdown(reports: List[Tuple[Path, Dict[str, Any]]]) -> str:
         requested = s.get("candidates_requested", s.get("epochs", "?"))
         usable = s.get("candidates_generated", s.get("epochs", "?"))
         total_checked = s.get("total_checked", 0)
+        total_skipped = s.get("total_skipped", 0)
         total_consistent = s.get("total_consistent", 0)
         total_inconsistent = s.get("total_inconsistent", 0)
         score = s.get("score", 0.0)
 
         lines.append(
             f"| {node} | {requested} | {usable} | "
-            f"{total_checked} | {total_consistent} | "
+            f"{total_checked} | {total_skipped} | {total_consistent} | "
             f"{total_inconsistent} | {score} % |"
         )
 
@@ -68,6 +69,7 @@ def build_markdown(reports: List[Tuple[Path, Dict[str, Any]]]) -> str:
         lines.append(f"- Candidate pool: `{s.get('candidates_pool', '?')}`")
         lines.append(f"- Queries performed: `{s.get('queries_performed', '?')}`")
         lines.append(f"- Total checks: `{s.get('total_checked', 0)}`")
+        lines.append(f"- Skipped: `{s.get('total_skipped', 0)}`")
         lines.append(f"- Consistent: `{s.get('total_consistent', 0)}`")
         lines.append(f"- Inconsistent: `{s.get('total_inconsistent', 0)}`")
         lines.append(f"- Score: **{s.get('score', 0.0)} %**")

--- a/src/eida_consistency/explorer.py
+++ b/src/eida_consistency/explorer.py
@@ -12,6 +12,7 @@ import requests
 
 from eida_consistency.services.availability import get_availability_spans
 from eida_consistency.services.dataselect import dataselect
+from eida_consistency.core.consistency import classify_consistency
 from eida_consistency.utils.nodes import load_node_url
 
 _BAR_WIDTH = 20
@@ -58,7 +59,7 @@ def _slice_consistent(
     t0: datetime,
     t1: datetime,
     verbose: bool = False,
-) -> bool:
+) -> bool | None:
     """
     Check if a time slice is consistent between availability and dataselect.
     Returns True if consistent, False if inconsistent.
@@ -82,7 +83,8 @@ def _slice_consistent(
     )
 
     ds = dataselect(base_url, net, sta, cha, _iso(ds_t0), _iso(ds_t1), loc)
-    consistent = window_covered == ds["success"]
+    classification = classify_consistency(window_covered, ds)
+    consistent = classification["consistent"]
 
     if verbose:
         logging.info(
@@ -131,7 +133,7 @@ def explore_boundaries(
     if indices:
         targets = [r for r in results if r["index"] in indices]
     else:
-        targets = [r for r in results if not r["consistent"]]
+        targets = [r for r in results if r.get("consistent") is False]
 
     if not targets:
         logging.info("No targets to explore (all consistent or no matching index).")
@@ -143,7 +145,7 @@ def explore_boundaries(
     summary: list[dict] = []
 
     for item_num, r in enumerate(targets, start=1):
-        if r.get("consistent", False):
+        if r.get("consistent") is not False:
             logging.debug(f"Index {r['index']} is marked consistent -> skipping.")
             continue
 
@@ -159,12 +161,22 @@ def explore_boundaries(
         t0_orig = datetime.combine(slice_start.date(), datetime.min.time(), tzinfo=timezone.utc)
         t1_orig = datetime.combine(slice_start.date(), datetime.max.time(), tzinfo=timezone.utc)
         
-        if _slice_consistent(base_url, net, sta, cha, loc, t0_orig, t1_orig, verbose):
+        current_status = _slice_consistent(base_url, net, sta, cha, loc, t0_orig, t1_orig, verbose)
+        if current_status is True:
             logging.info(f"  FIXED: This window is now consistent. Skipping exploration.")
             summary.append({
                 "label": label,
                 "window": f"{slice_start.date()} (Verified Fixed)",
                 "action": "Fixed",
+                "cmd": "-",
+            })
+            continue
+        if current_status is None:
+            logging.info("  TRANSIENT: Current Dataselect retrieval failed transiently. Skipping exploration.")
+            summary.append({
+                "label": label,
+                "window": f"{slice_start.date()} (Transient retrieval failure)",
+                "action": "Skipped",
                 "cmd": "-",
             })
             continue

--- a/src/eida_consistency/report/report.py
+++ b/src/eida_consistency/report/report.py
@@ -1,17 +1,14 @@
-"""Report-generation utilities.
+"""Report-generation utilities."""
 
-Creates JSON and Markdown summaries for the EIDA-consistency
-check results and provides cleanup helpers.
-"""
+from __future__ import annotations
 
 import json
 import os
-from pathlib import Path
 from collections import Counter
 from datetime import datetime, timezone
-from typing import List, Dict, Any, Optional
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
-# Default directory where reports are stored
 REPORT_DIR = Path("reports")
 
 
@@ -24,21 +21,26 @@ def create_report_object(
     candidates_requested: Optional[int] = None,
     candidates_tested: Optional[int] = None,
     station_queries: Optional[int] = None,
-    test_duration_sec: Optional[float] = None,   
+    test_duration_sec: Optional[float] = None,
 ) -> Dict[str, Any]:
-    """Build a serialisable dictionary summarising a full run."""
-
+    """Build a serializable dictionary summarizing a full run."""
     total_checked = len(records)
-    total_consistent = sum(1 for r in records if r["consistent"])
-    total_inconsistent = total_checked - total_consistent
-    score = (total_consistent / total_checked * 100.0) if total_checked > 0 else 0.0
+    scoreable_records = [r for r in records if r.get("scoreable", True)]
+    total_evaluated = len(scoreable_records)
+    total_skipped = total_checked - total_evaluated
+    total_consistent = sum(1 for r in scoreable_records if r["consistent"] is True)
+    total_inconsistent = sum(1 for r in scoreable_records if r["consistent"] is False)
+    score = (total_consistent / total_evaluated * 100.0) if total_evaluated > 0 else 0.0
 
-    # Breakdown by inconsistency type
     avail_yes_ds_no = sum(
-        1 for r in records if r["available"] and not r["dataselect_success"]
+        1
+        for r in scoreable_records
+        if r["consistent"] is False and r["available"] and not r["dataselect_success"]
     )
     avail_no_ds_yes = sum(
-        1 for r in records if (not r["available"]) and r["dataselect_success"]
+        1
+        for r in scoreable_records
+        if r["consistent"] is False and (not r["available"]) and r["dataselect_success"]
     )
 
     return {
@@ -49,11 +51,14 @@ def create_report_object(
             "candidates_requested": candidates_requested,
             "candidates_tested": candidates_tested,
             "station_queries": station_queries,
-            "duration": duration,  # per-epoch duration window
-            "test_duration_sec": test_duration_sec,  
+            "duration": duration,
+            "test_duration_sec": test_duration_sec,
             "total_checked": total_checked,
+            "total_evaluated": total_evaluated,
+            "total_skipped": total_skipped,
             "total_consistent": total_consistent,
             "total_inconsistent": total_inconsistent,
+            "total_transient": total_skipped,
             "score": round(score, 2),
             "availability_yes_dataselect_no": avail_yes_ds_no,
             "availability_no_dataselect_yes": avail_no_ds_yes,
@@ -72,9 +77,7 @@ def _make_unique_filename(node: str, seed: int, extension: str) -> str:
 def save_report_json(report: Dict[str, Any], report_dir: Path = REPORT_DIR) -> Path:
     """Save the full report as pretty-printed JSON and return the file path."""
     report_dir.mkdir(parents=True, exist_ok=True)
-    filename = _make_unique_filename(
-        report["summary"]["node"], report["summary"]["seed"], "json"
-    )
+    filename = _make_unique_filename(report["summary"]["node"], report["summary"]["seed"], "json")
     filepath = report_dir / filename
     filepath.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
     return filepath
@@ -83,80 +86,115 @@ def save_report_json(report: Dict[str, Any], report_dir: Path = REPORT_DIR) -> P
 def save_report_markdown(report: Dict[str, Any], report_dir: Path = REPORT_DIR) -> Path:
     """Save the report as a human-readable Markdown file."""
     report_dir.mkdir(parents=True, exist_ok=True)
-    filename = _make_unique_filename(
-        report["summary"]["node"], report["summary"]["seed"], "md"
-    )
+    filename = _make_unique_filename(report["summary"]["node"], report["summary"]["seed"], "md")
     filepath = report_dir / filename
 
     summary = report["summary"]
     results = report["results"]
-    type_counts = Counter(
-        r.get("dataselect_type", "?") for r in results if r.get("dataselect_type")
-    )
+    type_counts = Counter(r.get("dataselect_type", "?") for r in results if r.get("dataselect_type"))
+    inconsistent_recs = [r for r in results if r.get("consistent") is False]
+    skipped_recs = [r for r in results if not r.get("scoreable", True)]
 
-    inconsistent_recs = [r for r in results if not r["consistent"]]
+    md_lines = [f"# EIDA Consistency Report: `{summary['node']}`", ""]
 
-    md_lines = [
-        f"# EIDA Consistency Report: `{summary['node']}`",
-        "",
-    ]
-
-    if not inconsistent_recs:
-        md_lines.extend([
-            "## 🟢 Status: All Consistent",
-            "",
-            "No inconsistencies were detected in this run.",
-            "",
-        ])
-    else:
-        md_lines.extend([
-            "## 🔴 Detected Inconsistencies",
-            "",
-            "| Channel | Window (UTC) | Avail | DS | Type | Status |",
-            "| :--- | :--- | :---: | :---: | :---: | :--- |",
-        ])
+    if inconsistent_recs:
+        md_lines.extend(
+            [
+                "## Detected Inconsistencies",
+                "",
+                "| Channel | Window (UTC) | Avail | DS | Type | Status |",
+                "| :--- | :--- | :---: | :---: | :---: | :--- |",
+            ]
+        )
         for r in inconsistent_recs:
             chan = f"{r['network']}.{r['station']}.{r['location']}.{r['channel']}"
             window = f"{r['starttime']} → {r['endtime']}"
             avail = "Y" if r["available"] else "N"
             ds = "Y" if r["dataselect_success"] else "N"
-            dstype = r.get("dataselect_type", "?")
-            status = r["dataselect_status"]
-            md_lines.append(f"| `{chan}` | `{window}` | {avail} | {ds} | {dstype} | `{status}` |")
+            md_lines.append(
+                f"| `{chan}` | `{window}` | {avail} | {ds} | {r.get('dataselect_type', '?')} | `{r['dataselect_status']}` |"
+            )
+        md_lines.append("")
+    elif skipped_recs:
+        md_lines.extend(
+            [
+                "## No Scored Inconsistencies",
+                "",
+                "No scored inconsistencies were detected in this run, but some transient Dataselect failures were skipped.",
+                "",
+            ]
+        )
+    else:
+        md_lines.extend(["## Status: All Consistent", "", "No inconsistencies were detected in this run.", ""])
+
+    if skipped_recs:
+        md_lines.extend(
+            [
+                "## Service & Network Errors",
+                "",
+                "The following windows were skipped for scoring because Dataselect failed with a transient error (Connection, Timeout, 5xx).",
+                "While these are not counted as data inconsistencies, they may indicate service instability.",
+                "",
+                "| Channel | Window (UTC) | Avail | DS | Status |",
+                "| :--- | :--- | :---: | :---: | :--- |",
+            ]
+        )
+        for r in skipped_recs:
+            chan = f"{r['network']}.{r['station']}.{r['location']}.{r['channel']}"
+            window = f"{r['starttime']} → {r['endtime']}"
+            avail = "Y" if r["available"] else "N"
+            ds = "Y" if r["dataselect_success"] else "N"
+            status = r.get("consistency_reason") or r["dataselect_status"]
+            md_lines.append(f"| `{chan}` | `{window}` | {avail} | {ds} | `{status}` |")
         md_lines.append("")
 
-    md_lines.extend([
-        "---",
-        "",
-        "## Run Summary",
-        "",
-        f"- Seed: `{summary['seed']}`",
-        f"- Time: `{summary['timestamp']}`",
-        f"- Epochs requested: `{summary['epochs_requested']}`",
-        f"- Candidates requested: `{summary.get('candidates_requested', '?')}`",
-        f"- Candidates tested: `{summary.get('candidates_tested', '?')}`",
-        f"- Station queries performed: `{summary.get('station_queries', '?')}`",
-        f"- Duration/epoch: `{summary['duration']} s`",
-        f"- Test runtime: `{summary.get('test_duration_sec', '?')} s`", 
-        f"- Total checks run: `{summary['total_checked']}`",
-        f"- Consistent: `{summary['total_consistent']}`",
-        f"- Inconsistent: `{summary['total_inconsistent']}`",
-        f"- Score: **{summary['score']} %**",
-        "",
-        "### Inconsistency Breakdown",
-        f"- Availability says YES, Dataselect says NO: `{summary['availability_yes_dataselect_no']}`",
-        f"- Availability says NO, Dataselect says YES: `{summary['availability_no_dataselect_yes']}`",
-        "",
-        "### Dataselect Response Types",
-        *(f"- **{key}**: `{value}`" for key, value in sorted(type_counts.items())),
-        "",
-        "---",
-        "",
-        "## Detailed Results",
-        "",
-    ])
+    md_lines.extend(
+        [
+            "---",
+            "",
+            "## Run Summary",
+            "",
+            f"- Seed: `{summary['seed']}`",
+            f"- Time: `{summary['timestamp']}`",
+            f"- Epochs requested: `{summary['epochs_requested']}`",
+            f"- Candidates requested: `{summary.get('candidates_requested', '?')}`",
+            f"- Candidates tested: `{summary.get('candidates_tested', '?')}`",
+            f"- Station queries performed: `{summary.get('station_queries', '?')}`",
+            f"- Duration/epoch: `{summary['duration']} s`",
+            f"- Test runtime: `{summary.get('test_duration_sec', '?')} s`",
+            f"- Total checks run: `{summary['total_checked']}`",
+            f"- Scored checks: `{summary.get('total_evaluated', summary['total_checked'])}`",
+            f"- Skipped checks: `{summary.get('total_skipped', 0)}`",
+            f"- Consistent: `{summary['total_consistent']}`",
+            f"- Inconsistent: `{summary['total_inconsistent']}`",
+            f"- Score: **{summary['score']} %**",
+            "",
+            "### Quality Breakdown",
+            f"- Data Inconsistencies: `{summary['total_inconsistent']}`",
+            f"- Service/Network Errors: `{summary.get('total_transient', 0)}`",
+            "",
+            "### Inconsistency Breakdown",
+            f"- Availability says YES, Dataselect says NO: `{summary['availability_yes_dataselect_no']}`",
+            f"- Availability says NO, Dataselect says YES: `{summary['availability_no_dataselect_yes']}`",
+            "",
+            "### Dataselect Response Types",
+            *(f"- **{key}**: `{value}`" for key, value in sorted(type_counts.items())),
+            "",
+            "---",
+            "",
+            "## Detailed Results",
+            "",
+        ]
+    )
 
     for r in results:
+        if r["consistent"] is True:
+            consistency_text = "✔️"
+        elif r["consistent"] is False:
+            consistency_text = "❌"
+        else:
+            consistency_text = "Skipped"
+
         md_lines.extend(
             [
                 f"### `{r['network']}.{r['station']}.{r['location']}.{r['channel']}`",
@@ -165,7 +203,8 @@ def save_report_markdown(report: Dict[str, Any], report_dir: Path = REPORT_DIR) 
                 f"- Dataselect: `{r['dataselect_success']}`",
                 f"- Type: `{r.get('dataselect_type', '?')}`",
                 f"- Status: `{r['dataselect_status']}`",
-                f"- Consistent: `{'✔️' if r['consistent'] else '❌'}`",
+                f"- Scored: `{r.get('scoreable', True)}`",
+                f"- Consistent: `{consistency_text}`",
                 "",
             ]
         )
@@ -184,8 +223,8 @@ def delete_old_reports(report_dir: Path = REPORT_DIR, keep: int = 1) -> None:
 
     for json_file in to_delete:
         md_file = json_file.with_suffix(".md")
-        for f in (json_file, md_file):
+        for file_path in (json_file, md_file):
             try:
-                f.unlink()
+                file_path.unlink()
             except FileNotFoundError:
                 pass

--- a/src/eida_consistency/runner.py
+++ b/src/eida_consistency/runner.py
@@ -13,6 +13,7 @@ from typing import Optional
 from .services.station import fetch_candidates
 from .services.dataselect import dataselect
 from .core.checker import check_candidate
+from .core.consistency import classify_consistency
 from .utils.nodes import load_node_url
 from .core.formatter import format_result
 from .report.report import (
@@ -113,6 +114,7 @@ def run_consistency_check(
             match["network"], match["station"], match["channel"],
             start, end, loc_final
         )
+        classification = classify_consistency(available, ds_result)
         log = format_result(
             idx,
             url,
@@ -131,7 +133,10 @@ def run_consistency_check(
             "dataselect_success": ds_result["success"],
             "dataselect_status": ds_result["status"],
             "dataselect_type": ds_result.get("type", "?"),
-            "consistent": available == ds_result["success"],
+            "consistent": classification["consistent"],
+            "scoreable": classification["scoreable"],
+            "consistency_status": classification["status"],
+            "consistency_reason": classification["reason"],
             "starttime": str(start),
             "endtime": str(end),
             "debug": ds_result.get("debug", ""),

--- a/src/eida_consistency/services/dataselect.py
+++ b/src/eida_consistency/services/dataselect.py
@@ -7,6 +7,7 @@ Robust waveform fetch:
 
 from __future__ import annotations
 
+import time
 import traceback
 from io import BytesIO
 from urllib.parse import urlparse
@@ -41,81 +42,124 @@ def dataselect(
     end: str,
     loc: str = "",
     return_stream: bool = False,
-    timeout: int = 20,
+    timeout: int = 25,
+    max_attempts: int = 3,
 ):
     """
+    Retries dataselect query up to max_attempts on transient errors.
     Returns:
         dict: {
           success, status, type, error, debug, [stream]
         }
     """
     endpoint = _endpoint_from_base(base_url)
-    loc_code = (loc or "").strip()  # exact location only, no wildcard
-
-    # Attempt #1 — ObsPy FDSN Client
+    loc_code = (loc or "").strip()
     q1 = _build_query_url(endpoint, net, sta, loc_code, cha, start, end)
-    try:
-        client = Client(endpoint, timeout=timeout, user_agent=USER_AGENT)
-        st = client.get_waveforms(
-            network=net, station=sta, location=loc_code, channel=cha,
-            starttime=UTCDateTime(start), endtime=UTCDateTime(end)
-        )
-        n = len(st)
-        if n == 0:
-            return {
-                "success": False, "status": "NoData", "type": "NoTrace", "error": None,
-                "debug": f"❌ No waveform data (ObsPy client).\n{q1}",
+
+    last_error = None
+    last_status = "Unknown"
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            # Attempt #1 — ObsPy FDSN Client
+            client = Client(endpoint, timeout=timeout, user_agent=USER_AGENT)
+            st = client.get_waveforms(
+                network=net,
+                station=sta,
+                location=loc_code,
+                channel=cha,
+                starttime=UTCDateTime(start),
+                endtime=UTCDateTime(end),
+            )
+            n = len(st)
+            if n == 0:
+                return {
+                    "success": False,
+                    "status": "NoData",
+                    "type": "NoTrace",
+                    "error": None,
+                    "debug": f"❌ No waveform data (ObsPy client).\n{q1}",
+                }
+            info = "\n".join(str(tr) for tr in st)
+            res = {
+                "success": True,
+                "status": "OK",
+                "type": "MultiTrace" if n > 1 else "SingleTrace",
+                "error": None,
+                "debug": f"✅ Retrieved {n} trace(s) via ObsPy client.\n{info}\n{q1}",
             }
-        info = "\n".join(str(tr) for tr in st)
-        res = {
-            "success": True, "status": "OK",
-            "type": "MultiTrace" if n > 1 else "SingleTrace",
-            "error": None, "debug": f"✅ Retrieved {n} trace(s) via ObsPy client.\n{info}\n{q1}",
-        }
-        if return_stream:
-            res["stream"] = st
-        return res
+            if return_stream:
+                res["stream"] = st
+            return res
 
-    except AttributeError as e_attr:
-        # Known oddity: sometimes ObsPy hits AttributeError in internal path.
-        # Fall back to raw HTTP + obspy.read
-        pass
-    except Exception as e:
-        # Other failures also fall back
-        pass
+        except Exception as e:
+            last_error = traceback.format_exc()
+            last_status = type(e).__name__
+            # Fall through to raw HTTP attempt below
+            pass
 
-    # Attempt #2 — raw HTTP GET + obspy.read
-    try:
-        r = requests.get(q1, timeout=timeout, headers={"User-Agent": USER_AGENT})
-        if r.status_code == 204 or not r.content:
-            return {
-                "success": False, "status": "NoData", "type": "NoTrace", "error": None,
-                "debug": f"❌ No waveform bytes (HTTP {r.status_code}).\n{q1}",
+        # Attempt #2 — raw HTTP GET + obspy.read
+        try:
+            r = requests.get(q1, timeout=timeout, headers={"User-Agent": USER_AGENT})
+            if r.status_code == 204 or not r.content:
+                return {
+                    "success": False,
+                    "status": "NoData",
+                    "type": "NoTrace",
+                    "error": None,
+                    "debug": f"❌ No waveform bytes (HTTP {r.status_code}).\n{q1}",
+                }
+
+            if r.status_code >= 500:
+                last_status = f"HTTP {r.status_code}"
+                last_error = f"Server returned error {r.status_code}:\n{r.text[:500]}"
+                raise requests.exceptions.RequestException(f"Server Error {r.status_code}")
+
+            # Try to parse MiniSEED from the raw bytes
+            bio = BytesIO(r.content)
+            st = read(bio, format="MSEED")
+            n = len(st)
+            if n == 0:
+                return {
+                    "success": False,
+                    "status": "ParseError",
+                    "type": "NoTrace",
+                    "error": None,
+                    "debug": f"❌ Could not parse MiniSEED from HTTP bytes.\n{q1}",
+                }
+
+            info = "\n".join(str(tr) for tr in st)
+            res = {
+                "success": True,
+                "status": "OK",
+                "type": "MultiTrace" if n > 1 else "SingleTrace",
+                "error": None,
+                "debug": f"✅ Retrieved {n} trace(s) via raw HTTP+read().\n{info}\n{q1}",
             }
+            if return_stream:
+                res["stream"] = st
+            return res
 
-        # Try to parse MiniSEED from the raw bytes
-        bio = BytesIO(r.content)
-        st = read(bio, format="MSEED")
-        n = len(st)
-        if n == 0:
-            return {
-                "success": False, "status": "ParseError", "type": "NoTrace", "error": None,
-                "debug": f"❌ Could not parse MiniSEED from HTTP bytes.\n{q1}",
-            }
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout, requests.exceptions.RequestException) as e:
+            last_status = last_status if "HTTP" in last_status else type(e).__name__
+            last_error = last_error or traceback.format_exc()
+            if attempt < max_attempts:
+                wait = attempt * 2  # Linear backoff: 2s, 4s
+                time.sleep(wait)
+                continue
+        except Exception as e2:
+            last_status = type(e2).__name__
+            last_error = traceback.format_exc()
+            # If it's a parsing error or something non-network, don't retry?
+            # Actually, sometimes network glitches lead to truncated content and ParseError.
+            if attempt < max_attempts:
+                time.sleep(attempt)
+                continue
 
-        info = "\n".join(str(tr) for tr in st)
-        res = {
-            "success": True, "status": "OK",
-            "type": "MultiTrace" if n > 1 else "SingleTrace",
-            "error": None, "debug": f"✅ Retrieved {n} trace(s) via raw HTTP+read().\n{info}\n{q1}",
-        }
-        if return_stream:
-            res["stream"] = st
-        return res
-
-    except Exception as e2:
-        return {
-            "success": False, "status": type(e2).__name__, "type": "Error",
-            "error": traceback.format_exc(),
-            "debug": f"❌ Dataselect failed (both client and raw).\n{q1}",
-        }
+    return {
+        "success": False,
+        "status": last_status,
+        "type": "Error",
+        "error": last_error,
+        "debug": f"❌ Dataselect failed after {max_attempts} attempts.\n{q1}",
+    }

--- a/src/eida_consistency/services/day_availability.py
+++ b/src/eida_consistency/services/day_availability.py
@@ -1,17 +1,15 @@
-"""Day-level availability checks for EIDA.
-
-For a given day, fetch availability spans (TXT) and test consistency
-against a random 10-minute dataselect window inside that day.
-"""
+"""Day-level availability checks for EIDA."""
 
 from __future__ import annotations
+
 import logging
 import random
 from datetime import datetime, timedelta, timezone
-from typing import Dict, Any, List
+from typing import Any, Dict, List
 
 import requests
 
+from eida_consistency.core.consistency import classify_consistency
 from eida_consistency.services.dataselect import dataselect
 from eida_consistency.utils.constants import USER_AGENT
 
@@ -34,35 +32,37 @@ def _parse_iso(s: str) -> datetime:
 def _parse_text_availability(text: str) -> List[Dict[str, Any]]:
     """Parse text format availability response into spans."""
     spans: List[Dict[str, Any]] = []
-    lines = text.strip().splitlines()
-    for line in lines:
+    for line in text.strip().splitlines():
         if not line or line.startswith("#"):
             continue
         parts = line.split()
-        # 7 fields → no SampleRate, 8 fields → includes SampleRate
         if len(parts) == 7:
             net, sta, loc, cha, qual, start, end = parts
-            spans.append({
-                "network": net,
-                "station": sta,
-                "location": "" if loc in ("--", "*") else loc,
-                "channel": cha,
-                "quality": qual,
-                "start": start,
-                "end": end,
-            })
+            spans.append(
+                {
+                    "network": net,
+                    "station": sta,
+                    "location": "" if loc in ("--", "*") else loc,
+                    "channel": cha,
+                    "quality": qual,
+                    "start": start,
+                    "end": end,
+                }
+            )
         elif len(parts) >= 8:
             net, sta, loc, cha, qual, samplerate, start, end = parts[:8]
-            spans.append({
-                "network": net,
-                "station": sta,
-                "location": "" if loc in ("--", "*") else loc,
-                "channel": cha,
-                "quality": qual,
-                "samplerate": samplerate,
-                "start": start,
-                "end": end,
-            })
+            spans.append(
+                {
+                    "network": net,
+                    "station": sta,
+                    "location": "" if loc in ("--", "*") else loc,
+                    "channel": cha,
+                    "quality": qual,
+                    "samplerate": samplerate,
+                    "start": start,
+                    "end": end,
+                }
+            )
     return spans
 
 
@@ -75,16 +75,11 @@ def check_day_availability(
     location: str | None = "*",
     verbose: bool = False,
 ) -> Dict[str, Any]:
-    """Check if availability covers a random 10-min dataselect window in a given day."""
-
-    # Normalize location
+    """Check if availability covers a random 10-minute Dataselect window in a given day."""
     location = _normalize_location(location)
-
-    # Day boundaries
     t0 = datetime.combine(day, datetime.min.time(), tzinfo=timezone.utc)
     t1 = datetime.combine(day, datetime.max.time(), tzinfo=timezone.utc)
 
-    # Build availability URL (TXT + merged spans)
     avail_url = (
         f"{base_url}availability/1/query?"
         f"network={network}&station={station}&location={location}&channel={channel}"
@@ -93,47 +88,39 @@ def check_day_availability(
     if verbose:
         logging.info(f"  Availability URL: {avail_url}")
 
-    # Fetch availability spans
     try:
         resp = requests.get(avail_url, timeout=20, headers={"User-Agent": USER_AGENT})
         resp.raise_for_status()
         spans = _parse_text_availability(resp.text)
-    except Exception as e:
-        logging.error(f"[DayAvailability] Request failed: {e}")
+    except Exception as exc:
+        logging.error(f"[DayAvailability] Request failed: {exc}")
         return {"ok": False, "consistent": False, "availability_url": avail_url, "dataselect_url": None}
 
     if not spans:
         return {"ok": False, "consistent": False, "availability_url": avail_url, "dataselect_url": None}
 
-    # Pick random 10-min window
     rand_offset = random.randint(0, int((t1 - t0).total_seconds()) - 600)
     ds_start = t0 + timedelta(seconds=rand_offset)
     ds_end = ds_start + timedelta(minutes=10)
 
-    # Check if availability spans cover this window
-    covered = any(
-        _parse_iso(s["start"]) <= ds_start and _parse_iso(s["end"]) >= ds_end
-        for s in spans
-    )
+    covered = any(_parse_iso(s["start"]) <= ds_start and _parse_iso(s["end"]) >= ds_end for s in spans)
 
-    # Run dataselect for the 10-min window
-    ds_result = dataselect(
-        base_url, network, station, channel,
-        ds_start.isoformat(), ds_end.isoformat(), location
-    )
+    ds_result = dataselect(base_url, network, station, channel, ds_start.isoformat(), ds_end.isoformat(), location)
     ds_url = ds_result.get("url")
+    classification = classify_consistency(covered, ds_result)
 
     if verbose and ds_url:
         logging.info(f"  Dataselect URL:   {ds_url}")
         logging.info(
             f"  Result → availability covered={covered}, "
             f"dataselect success={ds_result['success']}, "
-            f"consistent={covered == ds_result['success']}"
+            f"consistent={classification['consistent']}"
         )
 
     return {
         "ok": True,
-        "consistent": covered == ds_result["success"],
+        "consistent": classification["consistent"],
+        "scoreable": classification["scoreable"],
         "availability_url": avail_url,
         "dataselect_url": ds_url,
         "availability_covered": covered,

--- a/tests/core/test_consistency.py
+++ b/tests/core/test_consistency.py
@@ -1,0 +1,36 @@
+from eida_consistency.core.consistency import classify_consistency, is_transient_dataselect_failure
+
+
+def test_is_transient_dataselect_failure_connection_error():
+    assert is_transient_dataselect_failure(False, "ConnectionError") is True
+
+
+def test_is_transient_dataselect_failure_timeout_family():
+    assert is_transient_dataselect_failure(False, "ReadTimeout") is True
+
+
+def test_is_transient_dataselect_failure_nodata_is_not_transient():
+    assert is_transient_dataselect_failure(False, "NoData") is False
+
+
+def test_classify_consistency_marks_transient_failure_as_skipped():
+    result = classify_consistency(True, {"success": False, "status": "ConnectionError"})
+    assert result["consistent"] is None
+    assert result["scoreable"] is False
+    assert result["status"] == "Skipped"
+
+
+def test_classify_consistency_marks_real_mismatch_as_inconsistent():
+    result = classify_consistency(True, {"success": False, "status": "NoData"})
+    assert result["consistent"] is False
+    assert result["scoreable"] is True
+    assert result["status"] == "Inconsistent"
+
+
+def test_is_transient_dataselect_failure_more_variants():
+    assert is_transient_dataselect_failure(False, "HTTP 503 Service Unavailable") is True
+    assert is_transient_dataselect_failure(False, "HTTP Error 500") is True
+    assert is_transient_dataselect_failure(False, "ProxyError") is True
+    assert is_transient_dataselect_failure(False, "SSLError") is True
+    assert is_transient_dataselect_failure(False, "Remote end closed connection without response") is True
+    assert is_transient_dataselect_failure(False, "Internal Server Error") is True

--- a/tests/core/test_formatter.py
+++ b/tests/core/test_formatter.py
@@ -35,14 +35,13 @@ def test_format_result_inconsistent_avail_yes_ds_no():
     assert "Consistent:   ❌" in out
 
 
-def test_format_result_inconsistent_avail_no_ds_yes():
+def test_format_result_skipped_transient_dataselect_failure():
     url = "http://fake/query"
-    ds_result = {"success": True, "status": "OK", "debug": ""}
-    out = formatter.format_result(3, url, False, ds_result, make_match())
+    ds_result = {"success": False, "status": "ConnectionError", "debug": ""}
+    out = formatter.format_result(3, url, True, ds_result, make_match())
 
-    assert "Availability: ❌" in out
-    assert "Dataselect:   ✅" in out
-    assert "Consistent:   ❌" in out
+    assert "Dataselect:   ❌ (ConnectionError)" in out
+    assert "Consistent:   ⚪ (Skipped: ConnectionError)" in out
 
 
 def test_format_result_with_missing_location_and_times():
@@ -52,7 +51,6 @@ def test_format_result_with_missing_location_and_times():
         "network": "YY",
         "station": "BBB",
         "channel": "EHN",
-        # no location, no endtime
         "starttime": "2020-05-01T00:00:00",
     }
     out = formatter.format_result(4, url, False, ds_result, match)
@@ -63,7 +61,6 @@ def test_format_result_with_missing_location_and_times():
 
 
 def test_format_result_with_matched_span_includes_start_end():
-    """Ensure matched_span start/end are appended when present in match dict."""
     url = "http://fake/query"
     ds_result = {"success": True, "status": "OK", "debug": ""}
     match = make_match()

--- a/tests/report/test_report.py
+++ b/tests/report/test_report.py
@@ -1,10 +1,18 @@
 import json
 import time
-from pathlib import Path
+
 import eida_consistency.report.report as report
 
 
-def make_record(consistent=True, available=True, ds_success=True, ds_type="M", status=200):
+def make_record(
+    consistent=True,
+    available=True,
+    ds_success=True,
+    ds_type="M",
+    status=200,
+    scoreable=True,
+    reason=None,
+):
     return {
         "network": "XX",
         "station": "STA",
@@ -17,50 +25,54 @@ def make_record(consistent=True, available=True, ds_success=True, ds_type="M", s
         "dataselect_type": ds_type,
         "dataselect_status": status,
         "consistent": consistent,
+        "scoreable": scoreable,
+        "consistency_reason": reason,
     }
 
 
-# -----------------
-# create_report_object
-# -----------------
-
 def test_create_report_object_basic():
-    records = [make_record(True), make_record(False, available=True, ds_success=False)]
-    rep = report.create_report_object("NODE", 123, 5, 600, records,
-                                      candidates_requested=5, candidates_tested=2, station_queries=1)
+    records = [
+        make_record(True),
+        make_record(False, available=True, ds_success=False),
+        make_record(None, available=True, ds_success=False, status="ConnectionError", scoreable=False, reason="TransientDataselectFailure"),
+    ]
+    rep = report.create_report_object(
+        "NODE",
+        123,
+        5,
+        600,
+        records,
+        candidates_requested=5,
+        candidates_tested=3,
+        station_queries=1,
+    )
     summary = rep["summary"]
     assert summary["node"] == "NODE"
-    assert summary["total_checked"] == 2
+    assert summary["total_checked"] == 3
+    assert summary["total_evaluated"] == 2
+    assert summary["total_skipped"] == 1
     assert summary["total_consistent"] == 1
     assert summary["total_inconsistent"] == 1
+    assert summary["total_transient"] == 1
+    assert summary["score"] == 50.0
     assert "availability_yes_dataselect_no" in summary
     assert "availability_no_dataselect_yes" in summary
     assert isinstance(summary["timestamp"], str)
+
 
 def test_create_report_object_empty_records():
     rep = report.create_report_object("NODE", 1, 1, 600, [])
     assert rep["summary"]["score"] == 0.0
     assert rep["summary"]["total_checked"] == 0
+    assert rep["summary"]["total_skipped"] == 0
 
 
-# -----------------
-# _make_unique_filename
-# -----------------
-
-def test_make_unique_filename_format(monkeypatch):
-    # The format is node_date_seed.json
-    # We can't easily mock datetime.now here without more setup, 
-    # but we can check the general structure.
+def test_make_unique_filename_format():
     fname = report._make_unique_filename("NODE", 42, "json")
-    # node_YYYYMMDD_HHMMSS_42.json
     assert fname.startswith("node_")
     assert "_42.json" in fname
-    assert len(fname.split("_")) == 4 # node, date, time, seed.extension
+    assert len(fname.split("_")) == 4
 
-
-# -----------------
-# save_report_json
-# -----------------
 
 def test_save_report_json_and_content(tmp_path):
     recs = [make_record()]
@@ -71,55 +83,42 @@ def test_save_report_json_and_content(tmp_path):
     assert data["summary"]["node"] == "NODE"
 
 
-# -----------------
-# save_report_markdown
-# -----------------
-
-def test_save_report_markdown(tmp_path):
+def test_save_report_markdown_with_skipped(tmp_path):
     recs = [
         make_record(True, ds_type="A"),
         make_record(False, ds_type="B"),
+        make_record(None, ds_success=False, ds_type="Error", status="ConnectionError", scoreable=False, reason="TransientDataselectFailure"),
     ]
-    rep = report.create_report_object("NODE", 2, 2, 600, recs)
+    rep = report.create_report_object("NODE", 2, 3, 600, recs)
     path = report.save_report_markdown(rep, report_dir=tmp_path)
     text = path.read_text(encoding="utf-8")
     assert "# EIDA Consistency Report" in text
-    assert "## 🔴 Detected Inconsistencies" in text
-    assert "## Run Summary" in text
-    assert "## Detailed Results" in text
-    assert "✔️" in text and "❌" in text
-    # Table headers
+    assert "## Detected Inconsistencies" in text
+    assert "## Service & Network Errors" in text
+    assert "Quality Breakdown" in text
+    assert "Service/Network Errors: `1`" in text
+    assert "Scored checks" in text
+    assert "Skipped checks" in text
+    assert "TransientDataselectFailure" in text
     assert "| Channel | Window (UTC) | Avail | DS | Type | Status |" in text
-    # Data row for inconsistency
-    assert "| `XX.STA.00.BHZ` |" in text
-    assert "B" in text
 
-
-# -----------------
-# delete_old_reports
-# -----------------
 
 def test_delete_old_reports(tmp_path):
-    # Create 3 JSON + MD reports
     recs = [make_record()]
     rep = report.create_report_object("NODE", 1, 1, 600, recs)
-    paths = []
-    for i in range(3):
-        p_json = report.save_report_json(rep, report_dir=tmp_path)
-        p_md = report.save_report_markdown(rep, report_dir=tmp_path)
-        paths.append((p_json, p_md))
-        time.sleep(0.01)  # ensure mtime ordering
+    for _ in range(3):
+        report.save_report_json(rep, report_dir=tmp_path)
+        report.save_report_markdown(rep, report_dir=tmp_path)
+        time.sleep(0.01)
 
-    # Keep only 1
     report.delete_old_reports(report_dir=tmp_path, keep=1)
 
     remaining = list(tmp_path.glob("*.json"))
     assert len(remaining) == 1
-    # corresponding md should also remain
     md_remaining = list(tmp_path.glob("*.md"))
     assert len(md_remaining) == 1
 
+
 def test_delete_old_reports_nonexistent_dir(tmp_path):
     non_existing = tmp_path / "not_here"
-    # Should not raise
     report.delete_old_reports(non_existing, keep=1)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -56,3 +56,32 @@ def test_print_stdout(monkeypatch, tmp_path, capsys):
     out = capsys.readouterr().out
     assert "summary" in out
     assert result == tmp_path / "out.json"
+
+
+def test_transient_dataselect_failure_is_marked_skipped(monkeypatch, tmp_path):
+    monkeypatch.setattr(runner, "fetch_candidates", lambda *a, **k: [make_fake_candidate()])
+    monkeypatch.setattr(runner, "check_candidate", lambda *a, **k: make_fake_result())
+    monkeypatch.setattr(
+        runner,
+        "dataselect",
+        lambda *a, **k: {"success": False, "status": "ConnectionError", "type": "Error", "debug": "network"},
+    )
+    monkeypatch.setattr(runner, "format_result", lambda *a, **k: "LOG")
+    monkeypatch.setattr(runner, "load_node_url", lambda node: "http://fake/")
+
+    captured = {}
+
+    def fake_create_report_object(**kwargs):
+        captured["records"] = kwargs["records"]
+        return {"summary": {}, "results": kwargs["records"]}
+
+    monkeypatch.setattr(runner, "create_report_object", fake_create_report_object)
+    monkeypatch.setattr(runner, "save_report_json", lambda report, report_dir: tmp_path / "out.json")
+    monkeypatch.setattr(runner, "save_report_markdown", lambda report, report_dir: tmp_path / "out.md")
+
+    result = runner.run_consistency_check("FAKE", seed=1, report_dir=tmp_path)
+    assert result == tmp_path / "out.json"
+    record = captured["records"][0]
+    assert record["consistent"] is None
+    assert record["scoreable"] is False
+    assert record["consistency_status"] == "Skipped"

--- a/uv.lock
+++ b/uv.lock
@@ -273,7 +273,7 @@ wheels = [
 
 [[package]]
 name = "eida-consistency"
-version = "0.4.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION


- Added a 3-attempt retry loop with backoff to dataselect service.
- Enhanced classify_consistency to recognize HTTP 5xx, Proxy, and SSL errors as transient.
- Updated report generation to clearly separate 'Service & Network Errors' from 'Data Inconsistencies'.
- Added 'Quality Breakdown' to report summaries for node operators.
- Updated test suite to verify transient failure handling.