### PR TITLE
feat(explore): add --json output for machine-readable fixes

### DIFF
--- a/src/eida_consistency/cli.py
+++ b/src/eida_consistency/cli.py
@@ -10,6 +10,7 @@ $ uv run eida-consistency reload-nodes
 $ uv run eida-consistency list-nodes
 """
 
+import json
 import logging
 from pathlib import Path
 from dotenv import load_dotenv
@@ -206,8 +207,13 @@ def check(ctx, node, net, sta, cha, loc, start, end):
     help="Maximum number of days to explore backward/forward."
 )
 @click.option("--verbose", is_flag=True, help="Print query URLs while exploring")
+@click.option(
+    "--json", "as_json", is_flag=True,
+    help="Emit the discovered fixes as JSON to stdout (machine-readable). "
+         "Human logs/progress stay on stderr, so stdout is pure JSON.",
+)
 @click.pass_context
-def explore(ctx, report, index, days, verbose):
+def explore(ctx, report, index, days, verbose, as_json):
     """Explore day-by-day boundaries of inconsistencies from a report."""
     report_dir: Path = ctx.obj["report_dir"]
 
@@ -219,7 +225,11 @@ def explore(ctx, report, index, days, verbose):
             raise click.UsageError(f"No report files found in {report_dir}")
 
     indices = list(index) if index else None
-    explore_boundaries(report, indices, max_days=days, verbose=verbose)
+    result = explore_boundaries(report, indices, max_days=days, verbose=verbose)
+    if as_json:
+        # stdout only -- logging/progress already went to stderr -- so a caller
+        # (e.g. `dmtri fix`) can parse stdout as JSON directly.
+        click.echo(json.dumps(result, indent=2, default=str))
 
 
 # ----------------------------------------------------------------------

--- a/src/eida_consistency/explorer.py
+++ b/src/eida_consistency/explorer.py
@@ -17,6 +17,11 @@ from eida_consistency.utils.nodes import load_node_url
 
 _BAR_WIDTH = 20
 
+# Version of the machine-readable fix schema returned by explore_boundaries and
+# emitted by `explore --json`. Bump on any breaking change to the fix records so
+# consumers (e.g. dmtri fix) can guard against incompatible output.
+SCHEMA_VERSION = "1.0"
+
 
 def _progress(direction: str, step: int, max_days: int, date: str) -> None:
     """Print an in-place progress bar to stderr (overwrites the same line)."""
@@ -113,11 +118,37 @@ def explore_boundaries(
     indices: Optional[List[int]] = None,
     max_days: int = 30,
     verbose: bool = False,
-) -> None:
+) -> dict:
     """
     Explore inconsistencies from a report.
     If indices is None, explores all inconsistent entries.
-    Prints a summary table at the end with windows and dmtri commands.
+    Prints a human-readable summary table at the end with windows and dmtri
+    commands (unchanged behavior).
+
+    Returns a machine-readable result dict::
+
+        {
+            "schema_version": SCHEMA_VERSION,
+            "node": "<node>",
+            "report": "<path or url>",
+            "fixes": [
+                {
+                    "index": <int>,
+                    "network": "..", "station": "..",
+                    "location": "..", "channel": "..",
+                    "start": "YYYY-MM-DD" | None,
+                    "end":   "YYYY-MM-DD" | None,
+                    "direction": "refresh" | "clean" | None,
+                    "status": "actionable" | "fixed" | "transient",
+                },
+                ...
+            ],
+        }
+
+    Only ``status == "actionable"`` fixes carry a window/direction; "fixed"
+    (already consistent again) and "transient" (dataselect failed transiently)
+    rows are reported with null window so a consumer can see they were evaluated
+    but need no action. The ``--json`` CLI flag dumps this dict to stdout.
     """
     report_path = str(report_path)
     if report_path.startswith("http://") or report_path.startswith("https://"):
@@ -137,12 +168,18 @@ def explore_boundaries(
 
     if not targets:
         logging.info("No targets to explore (all consistent or no matching index).")
-        return
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "node": report["summary"]["node"],
+            "report": report_path,
+            "fixes": [],
+        }
 
     node = report["summary"]["node"]
     base_url = load_node_url(node)
     total = len(targets)
     summary: list[dict] = []
+    fixes: list[dict] = []
 
     for item_num, r in enumerate(targets, start=1):
         if r.get("consistent") is not False:
@@ -170,6 +207,12 @@ def explore_boundaries(
                 "action": "Fixed",
                 "cmd": "-",
             })
+            fixes.append({
+                "index": r["index"], "network": net, "station": sta,
+                "location": loc, "channel": cha,
+                "start": None, "end": None, "direction": None,
+                "status": "fixed",
+            })
             continue
         if current_status is None:
             logging.info("  TRANSIENT: Current Dataselect retrieval failed transiently. Skipping exploration.")
@@ -178,6 +221,12 @@ def explore_boundaries(
                 "window": f"{slice_start.date()} (Transient retrieval failure)",
                 "action": "Skipped",
                 "cmd": "-",
+            })
+            fixes.append({
+                "index": r["index"], "network": net, "station": sta,
+                "location": loc, "channel": cha,
+                "start": None, "end": None, "direction": None,
+                "status": "transient",
             })
             continue
 
@@ -233,6 +282,12 @@ def explore_boundaries(
             "action": action,
             "cmd": dmtri_cmd,
         })
+        fixes.append({
+            "index": r["index"], "network": net, "station": sta,
+            "location": loc, "channel": cha,
+            "start": str(back), "end": str(forward),
+            "direction": cmd, "status": "actionable",
+        })
 
     # -- Final summary ---------------------------------------------------------
     sep = "-" * 72
@@ -249,3 +304,10 @@ def explore_boundaries(
         if i < n:
             logging.info("")
     logging.info(sep)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "node": node,
+        "report": report_path,
+        "fixes": fixes,
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 import logging
 from pathlib import Path
@@ -110,6 +111,75 @@ def test_explore_no_reports(tmp_path):
     result = runner.invoke(cli.explore, [], obj={"report_dir": tmp_path})
     assert result.exit_code != 0
     assert "No report files found" in result.output
+
+def test_explore_json_flag_outputs_json(monkeypatch, tmp_path):
+    f = tmp_path / "rep.json"
+    f.write_text("{}")
+    sample = {
+        "schema_version": "1.0",
+        "node": "NOA",
+        "report": str(f),
+        "fixes": [{
+            "index": 1, "network": "XX", "station": "STA",
+            "location": "00", "channel": "BHZ",
+            "start": "2008-01-01", "end": "2008-02-01",
+            "direction": "refresh", "status": "actionable",
+        }],
+    }
+    monkeypatch.setattr(cli, "explore_boundaries",
+                        lambda report, indices, max_days, verbose: sample)
+    runner = CliRunner()
+    result = runner.invoke(cli.explore, [str(f), "--json"], obj={"report_dir": tmp_path})
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)  # stdout must be pure JSON
+    assert parsed["schema_version"] == "1.0"
+    assert parsed["fixes"][0]["direction"] == "refresh"
+    assert parsed["fixes"][0]["status"] == "actionable"
+
+def test_explore_without_json_flag_prints_no_json(monkeypatch, tmp_path):
+    f = tmp_path / "rep.json"
+    f.write_text("{}")
+    monkeypatch.setattr(cli, "explore_boundaries",
+                        lambda report, indices, max_days, verbose: {"fixes": []})
+    runner = CliRunner()
+    result = runner.invoke(cli.explore, [str(f)], obj={"report_dir": tmp_path})
+    assert result.exit_code == 0
+    assert "schema_version" not in result.output  # no JSON dumped without the flag
+
+def test_explore_json_end_to_end(monkeypatch, tmp_path):
+    """--json runs the REAL explore_boundaries and emits structured fixes on stdout."""
+    import eida_consistency.explorer as explorer
+    report = tmp_path / "rep.json"
+    report.write_text(json.dumps({
+        "summary": {"node": "NOA"},
+        "results": [{
+            "index": 1, "network": "XX", "station": "STA",
+            "channel": "BHZ", "location": "00",
+            "starttime": "2023-01-01T00:00:00Z", "endtime": "2023-01-01T01:00:00Z",
+            "consistent": False, "available": True, "dataselect_success": False,
+        }],
+    }))
+    # availability covers the window, dataselect always fails -> inconsistent/actionable
+    monkeypatch.setattr(explorer, "get_availability_spans",
+                        lambda *a, **kw: [{"start": "2020-01-01T00:00:00", "end": "2025-01-01T00:00:00"}])
+    monkeypatch.setattr(explorer, "dataselect", lambda *a, **kw: {"success": False})
+    monkeypatch.setattr(explorer, "load_node_url", lambda node: "http://fake/")
+
+    runner = CliRunner()
+    result = runner.invoke(cli.explore, [str(report), "--json", "--days", "1"],
+                           obj={"report_dir": tmp_path})
+    assert result.exit_code == 0
+    # CliRunner folds stderr (progress/logs) into output; in a real terminal they
+    # are separate fds. The JSON block is emitted last, so parse from its first '{'.
+    parsed = json.loads(result.output[result.output.index("{"):])
+    assert parsed["schema_version"] == "1.0"
+    assert parsed["node"] == "NOA"
+    assert len(parsed["fixes"]) == 1
+    fix = parsed["fixes"][0]
+    assert (fix["network"], fix["station"], fix["location"], fix["channel"]) == ("XX", "STA", "00", "BHZ")
+    assert fix["direction"] == "clean"   # report: available=True, dataselect=False
+    assert fix["status"] == "actionable"
+    assert fix["start"] and fix["end"]
 
 
 # -----------------

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -83,6 +83,33 @@ def test_explore_boundaries_no_targets(tmp_path, caplog):
     explorer.explore_boundaries(rep)
     assert "No targets to explore" in caplog.text
 
+def test_explore_boundaries_no_targets_returns_empty(tmp_path):
+    rep = make_report(tmp_path / "rep.json", consistent=True)
+    result = explorer.explore_boundaries(rep)
+    assert result["schema_version"] == explorer.SCHEMA_VERSION
+    assert result["node"] == "NOA"
+    assert result["fixes"] == []
+
+def test_explore_boundaries_returns_structured_fixes(monkeypatch, tmp_path):
+    rep = make_report(tmp_path / "rep.json", consistent=False, avail=True, ds_success=False)
+    monkeypatch.setattr(explorer, "get_availability_spans",
+                        lambda *a, **kw: [{"start": "2020-01-01T00:00:00", "end": "2025-01-01T00:00:00"}])
+    monkeypatch.setattr(explorer, "dataselect", lambda *a, **kw: {"success": False})
+    monkeypatch.setattr(explorer, "load_node_url", lambda node: "http://fake/")
+
+    result = explorer.explore_boundaries(rep, indices=[1], max_days=1)
+
+    assert result["schema_version"] == explorer.SCHEMA_VERSION
+    assert result["node"] == "NOA"
+    assert len(result["fixes"]) == 1
+    fix = result["fixes"][0]
+    assert fix["index"] == 1
+    assert (fix["network"], fix["station"], fix["location"], fix["channel"]) == ("XX", "STA", "00", "BHZ")
+    # report row says available=True / dataselect_success=False -> clean direction
+    assert fix["direction"] == "clean"
+    assert fix["status"] == "actionable"
+    assert fix["start"] and fix["end"]  # boundary window populated
+
 def test_explore_boundaries_with_targets(monkeypatch, tmp_path, caplog):
     rep = make_report(tmp_path / "rep.json", consistent=False, avail=True, ds_success=False)
 


### PR DESCRIPTION
## What

Adds a `--json` flag to `eida-consistency explore` that emits the discovered fixes as **machine-readable JSON on stdout**, alongside the existing human-readable summary (which stays on stderr).

`explore_boundaries()` now **returns** a structured result dict instead of only logging:

```json
{
  "schema_version": "1.0",
  "node": "INGV",
  "report": "<path or url>",
  "fixes": [
    {
      "index": 7,
      "network": "IV", "station": "ABC", "location": "", "channel": "HHZ",
      "start": "2008-01-05", "end": "2008-03-12",
      "direction": "refresh",          // refresh | clean | null
      "status": "actionable"            // actionable | fixed | transient
    }
  ]
}
```

- Only `status: "actionable"` fixes carry a window/direction.
- `fixed` (now consistent again) and `transient` (dataselect failed transiently) rows are reported with a null window so a consumer can see they were evaluated but need no action.
- `schema_version` lets consumers guard against future breaking changes.

## Why

This is the machine-readable contract that **`dmtri fix` (EIDA/dmtri#33)** consumes to automate repairs from a consistency report — instead of scraping the human summary or the printed `uvx dmtri …` command strings. The structured data already existed inside `explore_boundaries`; this just returns it and exposes it via `--json`.

## Notes

- Human behavior is unchanged: without `--json`, output is exactly as before. Logs/progress go to **stderr**, so `explore --json` stdout is pure JSON.
- No new dependencies; no change to the heavy scientific stack.

## Tests

- `tests/test_explorer.py`: return-value structure (actionable fix fields + direction) and empty result on no targets.
- `tests/test_cli.py`: `--json` dumps parseable JSON; absent flag dumps none; **end-to-end** run through the real `explore_boundaries` (network mocked) asserting the emitted JSON.
- Full suite: **118 passed**.

