### PR TITLE
Fix availability/dataselect false positives: gap comparison + restricted data (#41, #42)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,14 @@
-# Claude Code local config (personal, not for version control)
+# AI assistant artifacts (personal, not for version control)
 .claude/
+docs/superpowers/
+CLAUDE.md
+AGENTS.md
+GEMINI.md
+.cursor/
+.cursorrules
+.aider*
+.mcp.json
+.github/copilot-instructions.md
 
 # Local MinIO dev server
 infra/minio-data/

--- a/src/eida_consistency/cli.py
+++ b/src/eida_consistency/cli.py
@@ -169,13 +169,13 @@ def check(ctx, node, net, sta, cha, loc, start, end):
     logging.info(f"Checking Availability for {net}.{sta}.{loc}.{cha}...")
     av_res = check_availability_query(base_url, net, sta, cha, start, end, location=loc or "*")
     available = bool(av_res["ok"])
-    
+
     # 2. Check Dataselect
     logging.info(f"Checking Dataselect for {net}.{sta}.{loc}.{cha}...")
     ds_res = dataselect(base_url, net, sta, cha, start, end, loc)
     ds_success = ds_res["success"]
-    classification = classify_consistency(available, ds_res)
-    
+    classification = classify_consistency(av_res.get("spans", []), ds_res, (start, end))
+
     logging.info(f"\nResults for {net}.{sta}.{loc}.{cha} ({start} -> {end}):")
     logging.info(f"  Availability: {'YES' if available else 'NO'} (status {av_res['status']})")
     logging.info(f"  Dataselect:   {'YES' if ds_success else 'NO'} (status {ds_res['status']})")
@@ -186,7 +186,10 @@ def check(ctx, node, net, sta, cha, loc, start, end):
         logging.info("  Summary: INCONSISTENT")
     else:
         logging.info(f"  Summary: SKIPPED ({classification['reason']})")
-        
+
+    for m in classification.get("mismatch", []):
+        logging.info(f"  Gap mismatch: {m['start']} -> {m['end']}")
+
     if not ds_success and ds_res.get("debug"):
         logging.debug(f"  Debug: {ds_res['debug']}")
 

--- a/src/eida_consistency/core/checker.py
+++ b/src/eida_consistency/core/checker.py
@@ -149,8 +149,9 @@ def check_candidate(
         available = bool(av_res["ok"])
         matched_span = av_res.get("matched_span")
         loc = matched_span["location"] if (matched_span and matched_span.get("location")) else sample.get("location", "")
+        spans = av_res.get("spans", [])
 
-        results.append((av_res["url"], available, s, e, loc, matched_span))
+        results.append((av_res["url"], available, s, e, loc, matched_span, spans))
         used.add(key)
 
     # Final summary line

--- a/src/eida_consistency/core/consistency.py
+++ b/src/eida_consistency/core/consistency.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+from eida_consistency.core.coverage import (
+    parse_iso, tolerance_seconds, clip_intervals, mismatch_intervals,
+)
+
 
 def is_transient_dataselect_failure(success: bool, status: str | None) -> bool:
     """Return True for transient transport-style Dataselect failures."""
@@ -30,8 +34,26 @@ def is_transient_dataselect_failure(success: bool, status: str | None) -> bool:
     return any(kw in normalized for kw in transient_keywords)
 
 
-def classify_consistency(available: bool, ds_result: Dict[str, Any]) -> Dict[str, Any]:
-    """Classify an availability/dataselect comparison."""
+def _first_samplerate(segments, spans):
+    """Pick a sample rate for tolerance: dataselect first, then availability."""
+    for seg in segments or []:
+        sr = seg[2] if len(seg) > 2 else None
+        if sr:
+            return sr
+    for s in spans or []:
+        sr = s.get("samplerate")
+        if sr:
+            return sr
+    return None
+
+
+def classify_consistency(spans, ds_result: Dict[str, Any], window) -> Dict[str, Any]:
+    """Compare availability spans vs dataselect segments within `window`.
+
+    spans:     list of availability span dicts ({"start","end","samplerate"}).
+    ds_result: dict from dataselect(), incl. "success", "status", "segments".
+    window:    (start_iso, end_iso) tuple of the test window.
+    """
     ds_success = bool(ds_result["success"])
     ds_status = ds_result.get("status")
 
@@ -41,12 +63,25 @@ def classify_consistency(available: bool, ds_result: Dict[str, Any]) -> Dict[str
             "scoreable": False,
             "status": "Skipped",
             "reason": "TransientDataselectFailure",
+            "mismatch": [],
         }
 
-    consistent = available == ds_success
+    w0, w1 = parse_iso(window[0]), parse_iso(window[1])
+    segments = ds_result.get("segments", [])
+    tol = tolerance_seconds(_first_samplerate(segments, spans))
+
+    avail_iv = [(parse_iso(s.get("start")), parse_iso(s.get("end"))) for s in (spans or [])]
+    ds_iv = [(parse_iso(seg[0]), parse_iso(seg[1])) for seg in segments]
+
+    a = clip_intervals(avail_iv, w0, w1)
+    d = clip_intervals(ds_iv, w0, w1)
+    mism = mismatch_intervals(a, d, tol)
+    consistent = len(mism) == 0
+
     return {
         "consistent": consistent,
         "scoreable": True,
         "status": "Consistent" if consistent else "Inconsistent",
         "reason": None,
+        "mismatch": [{"start": s.isoformat(), "end": e.isoformat()} for s, e in mism],
     }

--- a/src/eida_consistency/core/coverage.py
+++ b/src/eida_consistency/core/coverage.py
@@ -1,0 +1,99 @@
+"""Pure interval math for comparing availability vs dataselect coverage.
+
+All functions work on lists of (start, end) datetime tuples ("intervals").
+No obspy, no dicts, no I/O -- trivially unit-testable.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List, Optional, Sequence, Tuple
+
+Interval = Tuple[datetime, datetime]
+
+DEFAULT_TOLERANCE_FLOOR = 0.5  # seconds
+
+
+def parse_iso(s: Optional[str]) -> Optional[datetime]:
+    """Parse an ISO-8601 string to an aware UTC datetime, or None."""
+    if not s or not str(s).strip():
+        return None
+    try:
+        d = datetime.fromisoformat(str(s).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if d.tzinfo is None:
+        d = d.replace(tzinfo=timezone.utc)
+    return d
+
+
+def tolerance_seconds(samplerate, floor: float = DEFAULT_TOLERANCE_FLOOR) -> float:
+    """One sample period in seconds, never below `floor`."""
+    try:
+        sr = float(samplerate)
+    except (TypeError, ValueError):
+        sr = 0.0
+    if sr > 0:
+        return max(1.0 / sr, floor)
+    return floor
+
+
+def clip_intervals(intervals: Sequence[Interval], w0: datetime, w1: datetime) -> List[Interval]:
+    """Trim intervals to the window [w0, w1]; drop empty/None pieces."""
+    out: List[Interval] = []
+    for s, e in intervals:
+        if s is None or e is None:
+            continue
+        cs, ce = max(s, w0), min(e, w1)
+        if cs < ce:
+            out.append((cs, ce))
+    return out
+
+
+def merge_intervals(intervals: Sequence[Interval], tol: float) -> List[Interval]:
+    """Sort and glue intervals whose gap is <= tol seconds."""
+    items = sorted(
+        (s, e) for s, e in intervals
+        if s is not None and e is not None and s < e
+    )
+    if not items:
+        return []
+    merged: List[Interval] = [items[0]]
+    for s, e in items[1:]:
+        ls, le = merged[-1]
+        if (s - le).total_seconds() <= tol:
+            merged[-1] = (ls, max(le, e))
+        else:
+            merged.append((s, e))
+    return merged
+
+
+def _subtract(a: Sequence[Interval], b: Sequence[Interval]) -> List[Interval]:
+    """Interval difference a \\ b. Inputs assumed merged + sorted."""
+    result: List[Interval] = []
+    for s, e in a:
+        cur = s
+        for bs, be in b:
+            if be <= cur:
+                continue
+            if bs >= e:
+                break
+            if bs > cur:
+                result.append((cur, min(bs, e)))
+            cur = max(cur, be)
+            if cur >= e:
+                break
+        if cur < e:
+            result.append((cur, e))
+    return result
+
+
+def mismatch_intervals(a: Sequence[Interval], b: Sequence[Interval], tol: float) -> List[Interval]:
+    """Regions covered by exactly one of a/b and wider than tol seconds.
+
+    Empty result => the two coverage maps agree (Consistent).
+    """
+    ma = merge_intervals(a, tol)
+    mb = merge_intervals(b, tol)
+    diff = _subtract(ma, mb) + _subtract(mb, ma)
+    diff = [(s, e) for (s, e) in diff if (e - s).total_seconds() > tol]
+    return sorted(diff)

--- a/src/eida_consistency/core/formatter.py
+++ b/src/eida_consistency/core/formatter.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-from eida_consistency.core.consistency import classify_consistency
 
-
-def format_result(idx, url, available, ds_result, match):
+def format_result(idx, url, available, ds_result, match, classification):
     original_start = match.get("starttime", "?")
     original_end = match.get("endtime", "?")
 
@@ -23,7 +21,6 @@ def format_result(idx, url, available, ds_result, match):
     dataselect_status = "✅" if ds_result["success"] else f"❌ ({ds_result['status']})"
     log.append(f"     Dataselect:   {dataselect_status}")
 
-    classification = classify_consistency(available, ds_result)
     if classification["consistent"] is True:
         consistency_status = "✅"
     elif classification["consistent"] is False:
@@ -31,6 +28,10 @@ def format_result(idx, url, available, ds_result, match):
     else:
         consistency_status = f"⚪ ({classification['status']}: {ds_result['status']})"
     log.append(f"     Consistent:   {consistency_status}")
+
+    for m in classification.get("mismatch", []):
+        log.append(f"     Gap mismatch: {m['start']} → {m['end']}")
+
     log.append(f"     Epoch span: {original_start} → {original_end}")
 
     debug = ds_result.get("debug", "").strip()

--- a/src/eida_consistency/explorer.py
+++ b/src/eida_consistency/explorer.py
@@ -88,7 +88,7 @@ def _slice_consistent(
     )
 
     ds = dataselect(base_url, net, sta, cha, _iso(ds_t0), _iso(ds_t1), loc)
-    classification = classify_consistency(window_covered, ds)
+    classification = classify_consistency(spans, ds, (_iso(ds_t0), _iso(ds_t1)))
     consistent = classification["consistent"]
 
     if verbose:

--- a/src/eida_consistency/runner.py
+++ b/src/eida_consistency/runner.py
@@ -107,20 +107,21 @@ def run_consistency_check(
     all_logs, all_records = [], []
 
     def worker(args):
-        idx, (url, available, start, end, loc_exact, matched_span), match = args
+        idx, (url, available, start, end, loc_exact, matched_span, spans), match = args
         loc_final = loc_exact or match.get("location", "")
         ds_result = dataselect(
             base_url,
             match["network"], match["station"], match["channel"],
             start, end, loc_final
         )
-        classification = classify_consistency(available, ds_result)
+        classification = classify_consistency(spans, ds_result, (start, end))
         log = format_result(
             idx,
             url,
             available,
             ds_result,
             {**match, "location": loc_final, "matched_span": matched_span},
+            classification,
         )
         record = {
             "index": idx,
@@ -137,6 +138,7 @@ def run_consistency_check(
             "scoreable": classification["scoreable"],
             "consistency_status": classification["status"],
             "consistency_reason": classification["reason"],
+            "mismatch": classification.get("mismatch", []),
             "starttime": str(start),
             "endtime": str(end),
             "debug": ds_result.get("debug", ""),
@@ -149,7 +151,7 @@ def run_consistency_check(
         return log, record
 
     args_list = []
-    for idx, (url, available, start, end, loc_exact, matched_span) in enumerate(results, 1):
+    for idx, (url, available, start, end, loc_exact, matched_span, spans) in enumerate(results, 1):
         try:
             parts = url.split("?")[1].split("&")
             net = next(p.split("=")[1] for p in parts if p.startswith("network="))
@@ -167,7 +169,7 @@ def run_consistency_check(
             None,
         )
         if match:
-            args_list.append((idx, (url, available, start, end, loc_exact, matched_span), match))
+            args_list.append((idx, (url, available, start, end, loc_exact, matched_span, spans), match))
 
     pool_size = max(1, min(max_workers, len(args_list)))
     with concurrent.futures.ThreadPoolExecutor(max_workers=pool_size) as executor:

--- a/src/eida_consistency/services/availability.py
+++ b/src/eida_consistency/services/availability.py
@@ -106,6 +106,7 @@ def check_availability_query(
         f"{base_url}availability/1/query?"
         f"network={network}&station={station}&location={location}&channel={channel}"
         f"&start={starttime}&end={endtime}&format=text&merge=quality,overlap"
+        f"&includerestricted=false"
     )
     logging.debug(f"Availability (query) URL: {url}")
 
@@ -153,6 +154,7 @@ def get_availability_spans(
         f"{base_url}availability/1/query?"
         f"network={network}&station={station}&location={location}&channel={channel}"
         f"&start={starttime}&end={endtime}&format=text&merge=quality,overlap"
+        f"&includerestricted=false"
     )
     logging.debug(f"Availability (spans) URL: {url}")
 

--- a/src/eida_consistency/services/availability.py
+++ b/src/eida_consistency/services/availability.py
@@ -92,6 +92,36 @@ def _parse_text_availability(text: str) -> List[Dict[str, Any]]:
     return spans
 
 
+def _availability_request(
+    base_url: str,
+    network: str,
+    station: str,
+    channel: str,
+    starttime: str,
+    endtime: str,
+    location: str,
+):
+    """GET availability with includerestricted=FALSE; retry without it on HTTP 400.
+
+    Restricted data is hidden by default so it isn't falsely flagged as
+    inconsistent. Some nodes reject the parameter (HTTP 400) or require a
+    specific casing; if the first request 400s we drop the parameter and retry
+    once so those nodes still work. Returns (response, url).
+    """
+    base = (
+        f"{base_url}availability/1/query?"
+        f"network={network}&station={station}&location={location}&channel={channel}"
+        f"&start={starttime}&end={endtime}&format=text&merge=quality,overlap"
+    )
+    url = base + "&includerestricted=FALSE"
+    resp = requests.get(url, timeout=300, headers={"User-Agent": USER_AGENT})
+    if resp.status_code == 400:
+        logging.debug("[availability] includerestricted rejected (HTTP 400); retrying without it")
+        url = base
+        resp = requests.get(url, timeout=300, headers={"User-Agent": USER_AGENT})
+    return resp, url
+
+
 def check_availability_query(
     base_url: str,
     network: str,
@@ -102,16 +132,12 @@ def check_availability_query(
     location: str = "*",
 ) -> Dict[str, Any]:
     """Query availability for a specific [start,end] and check coverage."""
-    url = (
-        f"{base_url}availability/1/query?"
-        f"network={network}&station={station}&location={location}&channel={channel}"
-        f"&start={starttime}&end={endtime}&format=text&merge=quality,overlap"
-        f"&includerestricted=false"
-    )
-    logging.debug(f"Availability (query) URL: {url}")
-
+    url = ""
     try:
-        resp = requests.get(url, timeout=300, headers={"User-Agent": USER_AGENT})
+        resp, url = _availability_request(
+            base_url, network, station, channel, starttime, endtime, location
+        )
+        logging.debug(f"Availability (query) URL: {url}")
         if resp.status_code == 204:
             return {"ok": False, "matched_span": None, "spans": [], "status": 204, "url": url}
 
@@ -150,16 +176,12 @@ def get_availability_spans(
     location: str = "*",
 ) -> List[Dict[str, Any]]:
     """Fetch all spans for a channel in one request."""
-    url = (
-        f"{base_url}availability/1/query?"
-        f"network={network}&station={station}&location={location}&channel={channel}"
-        f"&start={starttime}&end={endtime}&format=text&merge=quality,overlap"
-        f"&includerestricted=false"
-    )
-    logging.debug(f"Availability (spans) URL: {url}")
-
+    url = ""
     try:
-        resp = requests.get(url, timeout=300, headers={"User-Agent": USER_AGENT})
+        resp, url = _availability_request(
+            base_url, network, station, channel, starttime, endtime, location
+        )
+        logging.debug(f"Availability (spans) URL: {url}")
         if resp.status_code == 204:
             return []
 

--- a/src/eida_consistency/services/dataselect.py
+++ b/src/eida_consistency/services/dataselect.py
@@ -17,6 +17,23 @@ from obspy.clients.fdsn import Client
 from obspy import UTCDateTime, read
 
 
+def _segments_from_stream(st) -> list:
+    """Extract (start_iso, end_iso, sampling_rate) per trace; defensive."""
+    segs = []
+    for tr in st:
+        try:
+            stats = tr.stats
+            start = stats.starttime
+            end = stats.endtime
+            start_iso = start.isoformat() if hasattr(start, "isoformat") else str(start)
+            end_iso = end.isoformat() if hasattr(end, "isoformat") else str(end)
+            sr = float(getattr(stats, "sampling_rate", 0.0) or 0.0)
+            segs.append((start_iso, end_iso, sr))
+        except Exception:
+            continue
+    return segs
+
+
 def _endpoint_from_base(base_url: str) -> str:
     """Preserve scheme/host (e.g. https://ws.resif.fr)."""
     p = urlparse(base_url)
@@ -79,6 +96,7 @@ def dataselect(
                     "type": "NoTrace",
                     "error": None,
                     "debug": f"❌ No waveform data (ObsPy client).\n{q1}",
+                    "segments": [],
                 }
             info = "\n".join(str(tr) for tr in st)
             res = {
@@ -87,6 +105,7 @@ def dataselect(
                 "type": "MultiTrace" if n > 1 else "SingleTrace",
                 "error": None,
                 "debug": f"✅ Retrieved {n} trace(s) via ObsPy client.\n{info}\n{q1}",
+                "segments": _segments_from_stream(st),
             }
             if return_stream:
                 res["stream"] = st
@@ -108,6 +127,7 @@ def dataselect(
                     "type": "NoTrace",
                     "error": None,
                     "debug": f"❌ No waveform bytes (HTTP {r.status_code}).\n{q1}",
+                    "segments": [],
                 }
 
             if r.status_code >= 500:
@@ -126,6 +146,7 @@ def dataselect(
                     "type": "NoTrace",
                     "error": None,
                     "debug": f"❌ Could not parse MiniSEED from HTTP bytes.\n{q1}",
+                    "segments": [],
                 }
 
             info = "\n".join(str(tr) for tr in st)
@@ -135,6 +156,7 @@ def dataselect(
                 "type": "MultiTrace" if n > 1 else "SingleTrace",
                 "error": None,
                 "debug": f"✅ Retrieved {n} trace(s) via raw HTTP+read().\n{info}\n{q1}",
+                "segments": _segments_from_stream(st),
             }
             if return_stream:
                 res["stream"] = st
@@ -162,4 +184,5 @@ def dataselect(
         "type": "Error",
         "error": last_error,
         "debug": f"❌ Dataselect failed after {max_attempts} attempts.\n{q1}",
+        "segments": [],
     }

--- a/tests/core/test_checker.py
+++ b/tests/core/test_checker.py
@@ -93,6 +93,7 @@ def test_check_candidate_success(monkeypatch):
         return {
             "ok": True,
             "matched_span": {"start": "2023-01-01T00:00:00", "end": "2023-01-01T23:59:59", "location": "00"},
+            "spans": [{"start": "2023-01-01T00:00:00", "end": "2023-01-01T23:59:59", "samplerate": "100.0"}],
             "status": 200,
             "url": "http://fake/availability/1/query?..."
         }
@@ -102,11 +103,12 @@ def test_check_candidate_success(monkeypatch):
     results, stats = checker.check_candidate("http://fake/", c, epochs=1, duration=600)
 
     assert len(results) == 1
-    url, available, s, e, loc, span = results[0]
+    url, available, s, e, loc, span, spans = results[0]
     assert url.startswith("http://fake/availability/1/query?")
     assert available is True
     assert loc == "00"
     assert isinstance(span, dict)
+    assert spans == [{"start": "2023-01-01T00:00:00", "end": "2023-01-01T23:59:59", "samplerate": "100.0"}]
     assert stats["candidates_generated"] == 1
     assert stats["candidates_requested"] == 1
 
@@ -128,7 +130,7 @@ def test_check_candidate_not_available(monkeypatch):
     results, stats = checker.check_candidate("http://fake/", c, epochs=1, duration=600)
     
     assert len(results) == 1
-    url, available, s, e, loc, span = results[0]
+    url, available, s, e, loc, span, spans = results[0]
     assert available is False
     assert span is None
     assert stats["candidates_generated"] == 1

--- a/tests/core/test_consistency.py
+++ b/tests/core/test_consistency.py
@@ -1,36 +1,73 @@
-from eida_consistency.core.consistency import classify_consistency, is_transient_dataselect_failure
+from eida_consistency.core.consistency import (
+    classify_consistency, is_transient_dataselect_failure,
+)
+
+WINDOW = ("2020-01-09T23:55:00", "2020-01-10T00:05:00")
 
 
-def test_is_transient_dataselect_failure_connection_error():
+def span(start, end, sr="100.0"):
+    return {"start": start, "end": end, "samplerate": sr}
+
+
+# --- transient detection unchanged ---
+def test_is_transient_connection_error():
     assert is_transient_dataselect_failure(False, "ConnectionError") is True
 
-
-def test_is_transient_dataselect_failure_timeout_family():
-    assert is_transient_dataselect_failure(False, "ReadTimeout") is True
-
-
-def test_is_transient_dataselect_failure_nodata_is_not_transient():
+def test_is_transient_nodata_is_not_transient():
     assert is_transient_dataselect_failure(False, "NoData") is False
 
-
-def test_classify_consistency_marks_transient_failure_as_skipped():
-    result = classify_consistency(True, {"success": False, "status": "ConnectionError"})
-    assert result["consistent"] is None
-    assert result["scoreable"] is False
-    assert result["status"] == "Skipped"
-
-
-def test_classify_consistency_marks_real_mismatch_as_inconsistent():
-    result = classify_consistency(True, {"success": False, "status": "NoData"})
-    assert result["consistent"] is False
-    assert result["scoreable"] is True
-    assert result["status"] == "Inconsistent"
-
-
-def test_is_transient_dataselect_failure_more_variants():
+def test_is_transient_more_variants():
     assert is_transient_dataselect_failure(False, "HTTP 503 Service Unavailable") is True
     assert is_transient_dataselect_failure(False, "HTTP Error 500") is True
     assert is_transient_dataselect_failure(False, "ProxyError") is True
     assert is_transient_dataselect_failure(False, "SSLError") is True
-    assert is_transient_dataselect_failure(False, "Remote end closed connection without response") is True
     assert is_transient_dataselect_failure(False, "Internal Server Error") is True
+
+
+# --- classification (scenarios 2,3,6,8,12,13) ---
+def test_transient_failure_skipped():                         # scenario 12
+    r = classify_consistency([], {"success": False, "status": "ConnectionError", "segments": []}, WINDOW)
+    assert r["consistent"] is None
+    assert r["scoreable"] is False
+    assert r["status"] == "Skipped"
+
+def test_identical_midnight_split_is_consistent():            # scenario 2 (#41)
+    spans = [span("2020-01-09T23:55:00", "2020-01-09T23:59:59"),
+             span("2020-01-10T00:00:00", "2020-01-10T00:05:00")]
+    ds = {"success": True, "status": "OK", "segments": [
+        ("2020-01-09T23:55:00", "2020-01-09T23:59:59", 100.0),
+        ("2020-01-10T00:00:00", "2020-01-10T00:05:00", 100.0)]}
+    r = classify_consistency(spans, ds, WINDOW)
+    assert r["consistent"] is True
+    assert r["status"] == "Consistent"
+    assert r["mismatch"] == []
+
+def test_big_shared_gap_is_consistent():                      # scenario 3
+    spans = [span("2020-01-09T23:55:00", "2020-01-09T23:58:00"),
+             span("2020-01-10T00:01:00", "2020-01-10T00:05:00")]
+    ds = {"success": True, "status": "OK", "segments": [
+        ("2020-01-09T23:55:00", "2020-01-09T23:58:00", 100.0),
+        ("2020-01-10T00:01:00", "2020-01-10T00:05:00", 100.0)]}
+    assert classify_consistency(spans, ds, WINDOW)["consistent"] is True
+
+def test_availability_has_data_dataselect_empty_is_inconsistent():  # scenario 8
+    spans = [span("2020-01-09T23:55:00", "2020-01-10T00:05:00")]
+    ds = {"success": False, "status": "NoData", "segments": []}
+    r = classify_consistency(spans, ds, WINDOW)
+    assert r["consistent"] is False
+    assert r["status"] == "Inconsistent"
+    assert len(r["mismatch"]) == 1
+
+def test_both_empty_is_consistent():                          # scenario 6 / restricted (16)
+    r = classify_consistency([], {"success": False, "status": "NoData", "segments": []}, WINDOW)
+    assert r["consistent"] is True
+
+def test_dataselect_hole_records_location():                  # scenario 4
+    spans = [span("2020-01-09T23:55:00", "2020-01-10T00:05:00")]
+    ds = {"success": True, "status": "OK", "segments": [
+        ("2020-01-09T23:55:00", "2020-01-09T23:58:00", 100.0),
+        ("2020-01-10T00:01:00", "2020-01-10T00:05:00", 100.0)]}
+    r = classify_consistency(spans, ds, WINDOW)
+    assert r["consistent"] is False
+    assert r["mismatch"][0]["start"].startswith("2020-01-09T23:58:00")
+    assert r["mismatch"][0]["end"].startswith("2020-01-10T00:01:00")

--- a/tests/core/test_coverage.py
+++ b/tests/core/test_coverage.py
@@ -1,0 +1,88 @@
+from eida_consistency.core import coverage as cov
+
+
+def dt(s):
+    return cov.parse_iso(s)
+
+
+# --- parse_iso / tolerance ---
+def test_parse_iso_naive_gets_utc():
+    d = cov.parse_iso("2020-01-01T00:00:00")
+    assert d.tzinfo is not None
+
+def test_parse_iso_invalid_returns_none():
+    assert cov.parse_iso("nope") is None
+    assert cov.parse_iso("") is None
+
+def test_tolerance_from_samplerate():
+    assert cov.tolerance_seconds(100.0) == 0.5   # 1/100=0.01 -> floored to 0.5
+    assert cov.tolerance_seconds(0.5) == 2.0     # 1/0.5=2.0 > floor
+    assert cov.tolerance_seconds(None) == 0.5    # floor
+    assert cov.tolerance_seconds("bad") == 0.5
+
+# --- clip ---
+def test_clip_drops_outside_and_trims():
+    w0, w1 = dt("2020-01-01T00:10:00"), dt("2020-01-01T00:20:00")
+    ivs = [(dt("2020-01-01T00:00:00"), dt("2020-01-01T00:15:00")),
+           (dt("2020-01-01T00:30:00"), dt("2020-01-01T00:40:00"))]
+    out = cov.clip_intervals(ivs, w0, w1)
+    assert out == [(w0, dt("2020-01-01T00:15:00"))]
+
+# --- merge ---
+def test_merge_glues_within_tolerance():
+    ivs = [(dt("2020-01-01T00:00:00"), dt("2020-01-01T00:01:00")),
+           (dt("2020-01-01T00:01:00"), dt("2020-01-01T00:02:00"))]
+    assert cov.merge_intervals(ivs, tol=1.0) == [(dt("2020-01-01T00:00:00"), dt("2020-01-01T00:02:00"))]
+
+def test_merge_keeps_real_gap():
+    ivs = [(dt("2020-01-01T00:00:00"), dt("2020-01-01T00:03:00")),
+           (dt("2020-01-01T00:06:00"), dt("2020-01-01T00:09:00"))]
+    assert len(cov.merge_intervals(ivs, tol=1.0)) == 2
+
+# --- mismatch: the core scenarios ---
+def test_identical_single_span_no_mismatch():       # scenario 1
+    a = [(dt("2020-01-01T00:00:00"), dt("2020-01-01T00:10:00"))]
+    assert cov.mismatch_intervals(a, list(a), tol=0.5) == []
+
+def test_identical_midnight_split_no_mismatch():    # scenario 2 (#41)
+    a = [(dt("2020-01-09T23:55:00"), dt("2020-01-09T23:59:59")),
+         (dt("2020-01-10T00:00:00"), dt("2020-01-10T00:05:00"))]
+    assert cov.mismatch_intervals(a, list(a), tol=0.01) == []
+
+def test_big_shared_gap_no_mismatch():              # scenario 3
+    a = [(dt("2020-01-01T00:00:00"), dt("2020-01-01T00:03:00")),
+         (dt("2020-01-01T00:06:00"), dt("2020-01-01T00:09:00"))]
+    assert cov.mismatch_intervals(a, list(a), tol=0.5) == []
+
+def test_dataselect_hole_is_flagged():              # scenario 4
+    a = [(dt("2020-01-01T00:00:00"), dt("2020-01-01T00:09:00"))]
+    d = [(dt("2020-01-01T00:00:00"), dt("2020-01-01T00:03:00")),
+         (dt("2020-01-01T00:06:00"), dt("2020-01-01T00:09:00"))]
+    out = cov.mismatch_intervals(a, d, tol=0.5)
+    assert out == [(dt("2020-01-01T00:03:00"), dt("2020-01-01T00:06:00"))]
+
+def test_dataselect_extra_data_is_flagged():        # scenario 5
+    a = [(dt("2020-01-01T00:00:00"), dt("2020-01-01T00:03:00"))]
+    d = [(dt("2020-01-01T00:00:00"), dt("2020-01-01T00:06:00"))]
+    out = cov.mismatch_intervals(a, d, tol=0.5)
+    assert out == [(dt("2020-01-01T00:03:00"), dt("2020-01-01T00:06:00"))]
+
+def test_both_empty_no_mismatch():                  # scenario 6
+    assert cov.mismatch_intervals([], [], tol=0.5) == []
+
+def test_one_side_empty_is_flagged():               # scenario 7/8
+    a = [(dt("2020-01-01T00:00:00"), dt("2020-01-01T00:10:00"))]
+    assert cov.mismatch_intervals(a, [], tol=0.5) == a
+    assert cov.mismatch_intervals([], a, tol=0.5) == a
+
+def test_subsample_edge_jitter_absorbed():          # scenario 9
+    a = [(dt("2020-01-01T00:00:00.000"), dt("2020-01-01T00:10:00.000"))]
+    d = [(dt("2020-01-01T00:00:00.003"), dt("2020-01-01T00:10:00.000"))]
+    assert cov.mismatch_intervals(a, d, tol=0.5) == []
+
+def test_mismatch_just_over_tolerance_is_flagged():  # scenario 10
+    a = [(dt("2020-01-01T00:00:00"), dt("2020-01-01T00:10:00"))]
+    d = [(dt("2020-01-01T00:00:02"), dt("2020-01-01T00:10:00"))]  # 2s > 0.5s
+    assert cov.mismatch_intervals(a, d, tol=0.5) == [
+        (dt("2020-01-01T00:00:00"), dt("2020-01-01T00:00:02"))
+    ]

--- a/tests/core/test_formatter.py
+++ b/tests/core/test_formatter.py
@@ -12,10 +12,16 @@ def make_match():
     }
 
 
+def cls(consistent, status, mismatch=None):
+    return {"consistent": consistent, "status": status,
+            "reason": None if consistent is not None else "TransientDataselectFailure",
+            "mismatch": mismatch or []}
+
+
 def test_format_result_consistent_ok():
     url = "http://fake/query"
     ds_result = {"success": True, "status": "OK", "debug": "extra-debug"}
-    out = formatter.format_result(1, url, True, ds_result, make_match())
+    out = formatter.format_result(1, url, True, ds_result, make_match(), cls(True, "Consistent"))
 
     assert url in out
     assert "Availability: ✅" in out
@@ -28,17 +34,20 @@ def test_format_result_consistent_ok():
 def test_format_result_inconsistent_avail_yes_ds_no():
     url = "http://fake/query"
     ds_result = {"success": False, "status": "NoData", "debug": ""}
-    out = formatter.format_result(2, url, True, ds_result, make_match())
+    out = formatter.format_result(2, url, True, ds_result, make_match(),
+                                  cls(False, "Inconsistent",
+                                      [{"start": "2020-01-01T00:03:00", "end": "2020-01-01T00:06:00"}]))
 
     assert "Availability: ✅" in out
     assert "Dataselect:   ❌ (NoData)" in out
     assert "Consistent:   ❌" in out
+    assert "00:03:00" in out  # mismatch interval shown
 
 
 def test_format_result_skipped_transient_dataselect_failure():
     url = "http://fake/query"
     ds_result = {"success": False, "status": "ConnectionError", "debug": ""}
-    out = formatter.format_result(3, url, True, ds_result, make_match())
+    out = formatter.format_result(3, url, True, ds_result, make_match(), cls(None, "Skipped"))
 
     assert "Dataselect:   ❌ (ConnectionError)" in out
     assert "Consistent:   ⚪ (Skipped: ConnectionError)" in out
@@ -53,7 +62,7 @@ def test_format_result_with_missing_location_and_times():
         "channel": "EHN",
         "starttime": "2020-05-01T00:00:00",
     }
-    out = formatter.format_result(4, url, False, ds_result, match)
+    out = formatter.format_result(4, url, False, ds_result, match, cls(False, "Inconsistent"))
 
     assert "Epoch span: 2020-05-01T00:00:00 → ?" in out
     assert "Availability: ❌" in out
@@ -69,7 +78,7 @@ def test_format_result_with_matched_span_includes_start_end():
         "end": "2020-01-01T02:00:00",
     }
 
-    out = formatter.format_result(5, url, True, ds_result, match)
+    out = formatter.format_result(5, url, True, ds_result, match, cls(True, "Consistent"))
 
     assert "2020-01-01T01:00:00" in out
     assert "2020-01-01T02:00:00" in out

--- a/tests/services/test_availability.py
+++ b/tests/services/test_availability.py
@@ -112,6 +112,26 @@ def test_check_availability_query_notcovered(monkeypatch):
     assert result["ok"] is False
     assert result["matched_span"] is None
 
+def test_check_availability_query_hides_restricted(monkeypatch):
+    captured = {}
+    def fake_get(url, *a, **k):
+        captured["url"] = url
+        return DummyResp(text="")
+    monkeypatch.setattr(requests, "get", fake_get)
+    avail.check_availability_query("http://x/", "HL", "STA", "HHZ",
+                                   "2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z")
+    assert "includerestricted=false" in captured["url"]
+
+def test_get_availability_spans_hides_restricted(monkeypatch):
+    captured = {}
+    def fake_get(url, *a, **k):
+        captured["url"] = url
+        return DummyResp(text="")
+    monkeypatch.setattr(requests, "get", fake_get)
+    avail.get_availability_spans("http://x/", "HL", "STA", "HHZ",
+                                 "2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z")
+    assert "includerestricted=false" in captured["url"]
+
 def test_check_availability_query_exception(monkeypatch):
     def bad_get(*a, **k): raise Exception("boom")
     monkeypatch.setattr(requests, "get", bad_get)

--- a/tests/services/test_availability.py
+++ b/tests/services/test_availability.py
@@ -120,7 +120,7 @@ def test_check_availability_query_hides_restricted(monkeypatch):
     monkeypatch.setattr(requests, "get", fake_get)
     avail.check_availability_query("http://x/", "HL", "STA", "HHZ",
                                    "2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z")
-    assert "includerestricted=false" in captured["url"]
+    assert "includerestricted=FALSE" in captured["url"]
 
 def test_get_availability_spans_hides_restricted(monkeypatch):
     captured = {}
@@ -130,7 +130,25 @@ def test_get_availability_spans_hides_restricted(monkeypatch):
     monkeypatch.setattr(requests, "get", fake_get)
     avail.get_availability_spans("http://x/", "HL", "STA", "HHZ",
                                  "2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z")
-    assert "includerestricted=false" in captured["url"]
+    assert "includerestricted=FALSE" in captured["url"]
+
+def test_availability_falls_back_when_includerestricted_rejected(monkeypatch):
+    """A node that 400s on includerestricted gets a retry without the param."""
+    calls = []
+    def fake_get(url, *a, **k):
+        calls.append(url)
+        if "includerestricted" in url:
+            return DummyResp(status=400, text="includerestricted should be TRUE or FALSE")
+        return DummyResp(text="HL STA -- HHZ D 100.0 2024-01-01T00:00:00Z 2024-01-03T00:00:00Z")
+    monkeypatch.setattr(requests, "get", fake_get)
+    result = avail.check_availability_query("http://x/", "HL", "STA", "HHZ",
+                                            "2024-01-01T12:00:00Z", "2024-01-02T12:00:00Z")
+    # first call had the param, second (retry) dropped it
+    assert len(calls) == 2
+    assert "includerestricted" in calls[0]
+    assert "includerestricted" not in calls[1]
+    # the retry succeeded and parsed spans
+    assert result["ok"] is True
 
 def test_check_availability_query_exception(monkeypatch):
     def bad_get(*a, **k): raise Exception("boom")

--- a/tests/services/test_dataselect.py
+++ b/tests/services/test_dataselect.py
@@ -1,5 +1,38 @@
+import types
 import pytest
 import eida_consistency.services.dataselect as ds
+
+
+def _fake_trace(start_iso, end_iso, sr):
+    stats = types.SimpleNamespace(
+        starttime=types.SimpleNamespace(isoformat=lambda s=start_iso: s),
+        endtime=types.SimpleNamespace(isoformat=lambda e=end_iso: e),
+        sampling_rate=sr,
+    )
+    return types.SimpleNamespace(stats=stats)
+
+
+def test_segments_extracted_from_stream(monkeypatch):
+    fake_stream = [
+        _fake_trace("2020-01-09T23:59:19", "2020-01-09T23:59:59", 100.0),
+        _fake_trace("2020-01-10T00:00:00", "2020-01-10T00:09:19", 100.0),
+    ]
+    monkeypatch.setattr(ds, "Client", lambda *a, **k: (_ for _ in ()).throw(RuntimeError))
+    monkeypatch.setattr(ds.requests, "get", lambda *a, **k: DummyResp(content=b"ok"))
+    monkeypatch.setattr(ds, "read", lambda bio, format=None: fake_stream)
+    r = ds.dataselect("https://h", "N", "S", "C", "2020-01-09", "2020-01-10")
+    assert r["success"]
+    assert r["segments"] == [
+        ("2020-01-09T23:59:19", "2020-01-09T23:59:59", 100.0),
+        ("2020-01-10T00:00:00", "2020-01-10T00:09:19", 100.0),
+    ]
+
+
+def test_segments_empty_on_nodata(monkeypatch):
+    monkeypatch.setattr(ds, "Client", lambda *a, **k: (_ for _ in ()).throw(RuntimeError))
+    monkeypatch.setattr(ds.requests, "get", lambda *a, **k: DummyResp(status=204))
+    r = ds.dataselect("https://h", "N", "S", "C", "2020", "2021")
+    assert r["segments"] == []
 
 
 class DummyResp:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -253,10 +253,12 @@ def test_check_command_inconsistent(monkeypatch, caplog):
 
     
     def fake_av(*args, **kwargs):
-        return {"ok": True, "status": 200}
-    
+        return {"ok": True, "status": 200,
+                "spans": [{"start": "2016-09-20T00:00:00", "end": "2016-10-19T00:00:00",
+                           "samplerate": "100.0"}]}
+
     def fake_ds(*args, **kwargs):
-        return {"success": False, "status": 204, "debug": "NO DATA"}
+        return {"success": False, "status": 204, "debug": "NO DATA", "segments": []}
     
     import eida_consistency.services.availability as av
     import eida_consistency.services.dataselect as ds

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -35,7 +35,9 @@ def test_slice_consistent_available_and_dataselect(monkeypatch, caplog):
                         lambda *a, **kw: [{"start": "2023-01-01T00:00:00",
                                            "end": "2023-01-01T02:00:00"}])
     monkeypatch.setattr(explorer, "dataselect",
-                        lambda *a, **kw: {"success": True})
+                        lambda *a, **kw: {"success": True,
+                                          "segments": [("2023-01-01T00:00:00",
+                                                        "2023-01-01T02:00:00", 100.0)]})
 
     caplog.set_level(logging.INFO)
     ok = explorer._slice_consistent("http://fake/", "XX", "STA", "BHZ", "00", t0, t1, verbose=True)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -12,7 +12,9 @@ def make_fake_candidate():
 
 def make_fake_result():
     url = "http://fake/fdsnws/availability/1/query?network=N&station=S&channel=C"
-    return [(url, True, "2024-01-01T00:00:00Z", "2024-01-01T01:00:00Z", "", {"start": "2024-01-01T00:00:00Z", "end": "2024-01-01T01:00:00Z", "location": ""})], {"stat": 1}
+    matched_span = {"start": "2024-01-01T00:00:00Z", "end": "2024-01-01T01:00:00Z", "location": ""}
+    spans = [{"start": "2024-01-01T00:00:00Z", "end": "2024-01-01T01:00:00Z", "samplerate": "100.0"}]
+    return [(url, True, "2024-01-01T00:00:00Z", "2024-01-01T01:00:00Z", "", matched_span, spans)], {"stat": 1}
 
 
 def patch_all(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Replaces the asymmetric boolean consistency check with a **segment/gap comparison** and stops flagging restricted data.

- **#41 — day-boundary false positive.** Previously a window was judged available only if a *single* availability span covered it, while dataselect only had to return *any* bytes. A channel split at midnight (a per-day-file artifact) therefore looked inconsistent even though both services agreed. Now we compare the two services' actual coverage intervals within one sample period: same data + same gaps → Consistent; a gap one side has and the other doesn't → Inconsistent, located exactly.
- **#42 — restricted data.** Availability is now queried with `includerestricted=FALSE`, so restricted channels aren't advertised and stop being falsely flagged.

## Key implementation notes

- New pure-function module `core/coverage.py` (clip / merge / mismatch on datetime intervals), heavily unit-tested.
- `dataselect` now exposes the per-trace `segments` it already parsed (no extra request).
- `classify_consistency(spans, ds_result, window)` reworked to coverage comparison; transient-failure → Skipped path preserved.
- Tolerance is one sample period (`1/samplerate`, 0.5s floor) — only absorbs sub-sample edge jitter, never bridges a real gap.
- `includerestricted=FALSE` is **uppercase on purpose**: verified across all 13 EIDA nodes — 12 are case-insensitive, RESIF (EPOS-France) strictly requires uppercase. A graceful fallback retries without the parameter if any node rejects it (HTTP 400), so nothing breaks.
